### PR TITLE
npm complaining (cryptically) that tiny version number not present in Cakefile

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -25,11 +25,11 @@ onerror = (err)->
 # Setup development dependencies, not part of runtime dependencies.
 task "setup", "Install development dependencies", ->
   log "Need Vows and Express to run test suite, installing ...", green
-  exec "npm install \"vows@>=0.\"5", onerror
-  exec "npm install \"express@>=1.0\"", onerror
+  exec "npm install \"vows@>=0.5.0\"", onerror
+  exec "npm install \"express@>=1.0.0\"", onerror
   log "Need Ronn and Docco to generate documentation, installing ...", green
-  exec "npm install \"ronn@>=0.3\"", onerror
-  exec "npm install \"docco@>=0.3\"", onerror
+  exec "npm install \"ronn@>=0.3.0\"", onerror
+  exec "npm install \"docco@>=0.3.0\"", onerror
   log "Need runtime dependencies, installing ...", green
   fs.readFile "package.json", "utf8", (err, package)->
     for name, version of JSON.parse(package).dependencies


### PR DESCRIPTION
Hi, I'm excited to use zombie, but I bumped into an issue with npm 0.2.13 where it was upset that the Cakefile specified versions >= without a tiny version number.  The message was rather cryptic so it took some digging to figure out (I'm new to npm).  This patch satisfies npm's issue.

Here was the error message, fwiw

```
[22:41][:~/src/zombie(master)]$ cake setup
Need Vows and Express to run test suite, installing ... 
Need Ronn and Docco to generate documentation, installing ... 
Need runtime dependencies, installing ... 
Error: Command failed: npm info it worked if it ends with ok
npm info using npm@0.2.13
npm info using node@v0.2.5
npm ERR! Error: Using '>=' with 1.0.x makes no sense. Don't do it.
npm ERR!     at /usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:94:29
npm ERR!     at String.replace (native)
npm ERR!     at replaceXRange (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:88:25)
npm ERR!     at Array.map (native)
npm ERR!     at replaceXRanges (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:84:17)
npm ERR!     at Array.map (native)
npm ERR!     at toComparators (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:66:8)
npm ERR!     at Object.validRange (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:138:11)
npm ERR!     at install_ (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/install.js:101:22)
npm ERR!     at /usr/local/lib/node/.npm/npm/0.2.13/package/lib/install.js:76:42
npm ERR! Report this *entire* log at <http://github.com/isaacs/npm/issues>
npm ERR! or email it to <npm-@googlegroups.com>
npm ERR! Just tweeting a tiny part of the error will not be helpful.
npm not ok

    at ChildProcess.exithandler (child_process:80:15)
    at ChildProcess.emit (events:27:15)
    at ChildProcess.onexit (child_process:168:12)
    at node.js:773:9
Error: Command failed: npm info it worked if it ends with ok
npm info using npm@0.2.13
npm info using node@v0.2.5
npm ERR! Error: Using '>=' with 0.5.x makes no sense. Don't do it.
npm ERR!     at /usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:94:29
npm ERR!     at String.replace (native)
npm ERR!     at replaceXRange (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:88:25)
npm ERR!     at Array.map (native)
npm ERR!     at replaceXRanges (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:84:17)
npm ERR!     at Array.map (native)
npm ERR!     at toComparators (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:66:8)
npm ERR!     at Object.validRange (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:138:11)
npm ERR!     at install_ (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/install.js:101:22)
npm ERR!     at /usr/local/lib/node/.npm/npm/0.2.13/package/lib/install.js:76:42
npm ERR! Report this *entire* log at <http://github.com/isaacs/npm/issues>
npm ERR! or email it to <npm-@googlegroups.com>
npm ERR! Just tweeting a tiny part of the error will not be helpful.
npm not ok

    at ChildProcess.exithandler (child_process:80:15)
    at ChildProcess.emit (events:27:15)
    at ChildProcess.onexit (child_process:168:12)
    at node.js:773:9
Error: Command failed: npm info it worked if it ends with ok
npm info using npm@0.2.13
npm info using node@v0.2.5
npm ERR! Error: Using '>=' with 0.3.x makes no sense. Don't do it.
npm ERR!     at /usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:94:29
npm ERR!     at String.replace (native)
npm ERR!     at replaceXRange (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:88:25)
npm ERR!     at Array.map (native)
npm ERR!     at replaceXRanges (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:84:17)
npm ERR!     at Array.map (native)
npm ERR!     at toComparators (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:66:8)
npm ERR!     at Object.validRange (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:138:11)
npm ERR!     at install_ (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/install.js:101:22)
npm ERR!     at /usr/local/lib/node/.npm/npm/0.2.13/package/lib/install.js:76:42
npm ERR! Report this *entire* log at <http://github.com/isaacs/npm/issues>
npm ERR! or email it to <npm-@googlegroups.com>
npm ERR! Just tweeting a tiny part of the error will not be helpful.
npm not ok

    at ChildProcess.exithandler (child_process:80:15)
    at ChildProcess.emit (events:27:15)
    at ChildProcess.onexit (child_process:168:12)
    at node.js:773:9
Error: Command failed: npm info it worked if it ends with ok
npm info using npm@0.2.13
npm info using node@v0.2.5
npm ERR! Error: Using '>=' with 0.3.x makes no sense. Don't do it.
npm ERR!     at /usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:94:29
npm ERR!     at String.replace (native)
npm ERR!     at replaceXRange (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:88:25)
npm ERR!     at Array.map (native)
npm ERR!     at replaceXRanges (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:84:17)
npm ERR!     at Array.map (native)
npm ERR!     at toComparators (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:66:8)
npm ERR!     at Object.validRange (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/utils/semver.js:138:11)
npm ERR!     at install_ (/usr/local/lib/node/.npm/npm/0.2.13/package/lib/install.js:101:22)
npm ERR!     at /usr/local/lib/node/.npm/npm/0.2.13/package/lib/install.js:76:42
npm ERR! Report this *entire* log at <http://github.com/isaacs/npm/issues>
npm ERR! or email it to <npm-@googlegroups.com>
npm ERR! Just tweeting a tiny part of the error will not be helpful.
npm not ok

    at ChildProcess.exithandler (child_process:80:15)
    at ChildProcess.emit (events:27:15)
    at ChildProcess.onexit (child_process:168:12)
    at node.js:773:9
```
