### PR TITLE
Fix for Issue #34

### DIFF
--- a/src/zombie/cookies.coffee
+++ b/src/zombie/cookies.coffee
@@ -132,9 +132,9 @@ class Cookies
     #
     # Adds Cookie header suitable for sending to the server.
     this.addHeader = (headers)->
-      header = ("#{match[2]}=\"#{match[3].value}\";$Path=\"#{match[1]}\"" for match in selected()).join("; ")
+      header = ("#{match[2]}=#{match[3].value};$Path=#{match[1]}" for match in selected()).join("; ")
       if header.length > 0
-        headers.cookie = "$Version=\"1\"; #{header}"
+        headers.cookie = "$Version=1; #{header}"
 
     #### cookies(host, path).pairs => String
     #


### PR DESCRIPTION
Not sure if this is the correct way to fix. It seems when you quote the params on cookie header fields the web server (Apache/2.0.63 in this case) discards the cookie as an invalid. Did not have a chance to test on other servers but would suspect similar behavior exists. This doesn't make sense according to both the RFC 2965 and older RFC 2109 which seem to explicitly state quoting those params is expected. So, in short, this works, but it's not what the spec defines. Go figure!

Also thanks for zombie - it be loads of awesome!

-Norm
