### PR TITLE
Fix for loading scripts over SSL

### DIFF
--- a/spec/script-spec.coffee
+++ b/spec/script-spec.coffee
@@ -84,6 +84,24 @@ brains.get "/living", (req, res)-> res.send """
     </body>
   </html>
   """
+
+brains.get "/script/ssl", (req, res)-> res.send """
+  <html>
+    <head>
+      <script>
+        function jsonp(response) {
+          document.title = response[2].id;
+        }
+      </script>
+
+      <script src="https://api.mercadolibre.com/sites/MLA?callback=jsonp"></script>
+    </head>
+    <body>
+
+    </body>
+  </html>
+  """
+
 brains.get "/app.js", (req, res)-> res.send """
   Sammy("#main", function(app) {
     app.get("#/", function(context) {
@@ -145,5 +163,10 @@ vows.describe("Scripts").addBatch(
       topic: (browser)->
         browser.evaluate "document.title"
       "should evaluate in context and return value": (title)-> assert.equal title, "The Living"
+
+  "SSL":
+    zombie.wants "http://localhost:3003/script/ssl"
+      "should load scripts over SSL": (browser)->
+        assert.equal browser.window.title, "MLA"
 
 ).export(module)

--- a/src/zombie/jsdom_patches.coffee
+++ b/src/zombie/jsdom_patches.coffee
@@ -9,7 +9,7 @@ html5 = require("html5").HTML5
 # ---------------
 
 # Default behavior for clicking on links: navigate to new URL is specified.
-core.HTMLAnchorElement.prototype._eventDefaults = 
+core.HTMLAnchorElement.prototype._eventDefaults =
   click: (event)->
     anchor = event.target
     anchor.ownerDocument.parentWindow.location = anchor.href if anchor.href
@@ -36,7 +36,9 @@ core.resourceLoader.load = (element, href, callback)->
 # Adds redirect support when loading resources (JavaScript).
 core.resourceLoader.download = (url, callback)->
   path = url.pathname + (url.search || "")
-  client = http.createClient(url.port || 80, url.hostname)
+  secure = url.protocol == "https:"
+  port = url.port || (if secure then 443 else 80)
+  client = http.createClient(port, url.hostname, secure)
   request = client.request("GET", path, "host": url.hostname)
   request.on "response", (response)->
     response.setEncoding "utf8"


### PR DESCRIPTION
Will make another change on top of this to abstract the logic of creating a client for a given URL.
