### PR TITLE
Cookie quotes

### DIFF
--- a/spec/cookie-spec.coffee
+++ b/spec/cookie-spec.coffee
@@ -125,4 +125,13 @@ vows.describe("Cookies").addBatch(
       assert.equal "bar", browser.cookies("localhost").get("foo")
       assert.equal "bar", browser.cookies("www.localhost").get("foo")
 
+  "setting Cookie header":
+    topic: (browser)->
+      browser = new zombie.Browser()
+      header = {cookie: ''}
+      browser.cookies("localhost").update("foo=bar;")
+      browser.cookies("localhost").addHeader header
+      header
+    "should set the header according to the spec": (header)-> assert.equal header.cookie, "$Version=1; foo=bar;$Path=/"
+
 ).export(module)

--- a/src/zombie/cookies.coffee
+++ b/src/zombie/cookies.coffee
@@ -132,9 +132,9 @@ class Cookies
     #
     # Adds Cookie header suitable for sending to the server.
     this.addHeader = (headers)->
-      header = ("#{match[2]}=\"#{match[3].value}\";$Path=\"#{match[1]}\"" for match in selected()).join("; ")
+      header = ("#{match[2]}=#{match[3].value};$Path=#{match[1]}" for match in selected()).join("; ")
       if header.length > 0
-        headers.cookie = "$Version=\"1\"; #{header}"
+        headers.cookie = "$Version=1; #{header}"
 
     #### cookies(host, path).pairs => String
     #


### PR DESCRIPTION
Hello!

I was using Zombie.js (with capybara-zombie) and we noticed a strange behavior on the server side on how cookies were being received:

{"$Path"=>"\"/\"", "_devs_at_work_session"=>"\"BAh7CCIPc2Vzc2lvbl9pZCIlYjRmZDVkMzlhYjQ1ZmYzM2YyYjQzYjRmYmE4NmVhZTkiGXdhcmRlbi51c2VyLnVzZXIua2V5WwgiCVVzZXJbBmkEnIPPECIiJDJhJDEwJEVtRXplWGltWk9Ec0dQN0UuQnczZ3UiCmZsYXNoSUM6JUFjdGlvbkRpc3BhdGNoOjpGbGFzaDo6Rmxhc2hIYXNoewY6C25vdGljZSIcU2lnbmVkIGluIHN1Y2Nlc3NmdWxseS4GOgpAdXNlZG86CFNldAY6CkBoYXNoewA=--d0a720581b13543f724b3285434c8b4bf392a895\"", "$Version"=>"\"1\""}

According to the specification, the values should be sent without quoting:

```
Each cookie begins with a NAME=VALUE pair, followed by zero or more
semi-colon-separated attribute-value pairs.
```

So this patch is to fix that, and also added unit tests to assert that.
