### PR TITLE
Dumping cookies causes a crash

### DIFF
--- a/src/zombie/cookies.coffee
+++ b/src/zombie/cookies.coffee
@@ -152,7 +152,7 @@ class Cookies
     # debugging.  If you need to save/load, use comma as the line
     # separator and then call `cookies.update`.
     this.dump = (separator = "\n")->
-      (@serialize(browser, match[0], match[1], match[2], match[3]) for match in selected()).join(separator)
+      (serialize(browser, match[0], match[1], match[2], match[3]) for match in selected()).join(separator)
 
 
 # ### document.cookie => String


### PR DESCRIPTION
Test Code:
    var http = require('http'),
        zombie = require('./zombie/index.js');

```
http.createServer(function (req, res) {
    res.writeHead(200, {'Content-Type': 'text/plain', 'Set-Cookie': 'test=value; domain=127.0.0.1; HttpOnly'});
    res.end('Hello World\n');
}).listen(8124, "127.0.0.1");

var browser = new zombie.Browser({ debug: true });

browser.visit('http://127.0.0.1:8124/', function(err, browser, status) {
    console.log(browser.cookies('127.0.0.1', '/').dump());
});
```

Crash:
    mbp:tmp cjoudrey$ node test.js
    Zombie: GET http://127.0.0.1:8124/
    Zombie: GET http://127.0.0.1:8124/ => 200

```
node.js:116
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
TypeError: Object #<Cookies> has no method 'serialize'
    at Cookies.<anonymous> (/private/tmp/zombie/lib/zombie/cookies.js:207:30)
    at Cookies.dump (/private/tmp/zombie/lib/zombie/cookies.js:210:10)
    at /private/tmp/test.js:11:51
    at /private/tmp/zombie/lib/zombie/browser.js:242:20
    at Browser.<anonymous> (/private/tmp/zombie/lib/zombie/browser.js:136:18)
    at Browser.<anonymous> (/private/tmp/zombie/lib/zombie/browser.js:9:60)
    at Browser.emit (events.js:42:17)
    at EventLoop.<anonymous> (/private/tmp/zombie/lib/zombie/eventloop.js:142:26)
    at Array.<anonymous> (/private/tmp/zombie/lib/zombie/eventloop.js:2:61)
    at EventEmitter._tickCallback (node.js:108:26)
```

This is due to:
    _results.push(this.serialize(browser, match[0], match[1], match[2], match[3]));

Which should be:
    _results.push(serialize(browser, match[0], match[1], match[2], match[3]));
