### PR TITLE
Resources.coffee updated to Node 0.4.x; HTTPS added to protocols recognized by XHR.

### DIFF
--- a/src/zombie/xhr.coffee
+++ b/src/zombie/xhr.coffee
@@ -1,6 +1,5 @@
 # window.XMLHttpRequest
 core = require("jsdom").dom.level3.core
-http = require("http")
 URL = require("url")
 
 
@@ -46,7 +45,7 @@ XMLHttpRequest = (window)->
       url.host = if url.port then "#{url.hostname}:#{url.port}" else url.hostname
       url.hash = null
       throw new core.DOMException(core.SECURITY_ERR, "Cannot make request to different domain") unless url.host == window.location.host
-      throw new core.DOMException(core.NOT_SUPPORTED_ERR, "Only HTTP protocol supported") unless url.protocol == "http:"
+      throw new core.DOMException(core.NOT_SUPPORTED_ERR, "Only HTTP protocol supported") unless url.protocol in ["http:", "https:"]
       [user, password] = url.auth.split(":") if url.auth
 
       # Aborting open request.


### PR DESCRIPTION
I've modified resources.coffee and xhr.coffee to use the node 0.4.x client.request() API, which is cleaner and recommended.  The 0.3.x API is deprecated.  Also, I added 'https' to the list of protocols supported by XHR.

Thanks for Zombie, though.  It's an excellent project.
