### PR TITLE
Fixed XHR's getAllResponseHeaders method, which should return a string

### DIFF
--- a/src/zombie/xhr.coffee
+++ b/src/zombie/xhr.coffee
@@ -74,7 +74,14 @@ XMLHttpRequest = (window)->
           else
             # At this state, allow retrieving of headers and status code.
             @getResponseHeader = (header)-> response.headers[header.toLowerCase()]
-            @getAllResponseHeaders = -> response.headers
+            @getAllResponseHeaders = ->
+              ###
+              XHR's getAllResponseHeaders, against all reason, returns a multi-line string.
+              See http://www.w3.org/TR/XMLHttpRequest/#the-getallresponseheaders-method
+              ###
+              headerStrings = for header, value of response.headers
+                "#{header}: #{value}"
+              return headerStrings.join("\n")
             @__defineGetter__ "status", -> response.statusCode
             @__defineGetter__ "statusText", -> response.statusText
             stateChanged 2


### PR DESCRIPTION
getAllResponseHeaders is supposed to return a string with one header/value pair on each line, not a Javascript object. This patch fixes it and adds a regression test for getResponseHeader and getAllResponseHeaders.
