### PR TITLE
Fix for #173 - brower.open() causes Segmentation fault

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node": ">= 0.4.0"
   },
   "dependencies": {
-    "contextify": "~0.0.5",
+    "contextify": "~0.0.6",
     "jsdom": "~0.2.4",
     "mime": "~1.2.3",
     "websocket-client": "~1.0.0"

--- a/src/zombie/storage.coffee
+++ b/src/zombie/storage.coffee
@@ -117,9 +117,9 @@ class Storages
     # Extend window with local/session storage support.
     this.extend = (window)->
       window.__defineGetter__ "sessionStorage", ->
-        @document._sessionStorage ||= browser.sessionStorage(@location.host)
+        @document?._sessionStorage ||= browser.sessionStorage(@location.host)
       window.__defineGetter__ "localStorage", ->
-        @document._localStorage ||= browser.localStorage(@location.host)
+        @document?._localStorage ||= browser.localStorage(@location.host)
 
     # Used to dump state to console (debuggin)
     this.dump = ->


### PR DESCRIPTION
The issue was that calling console.log on a new Browser before loading a page would cause the window.sessionStorage and window.localStorage getters to fire before a document for the window existed.  I added a check to make sure that the document exists before accessing its properties.

The segfault was from Contextify not handling the missing property case correctly.  I fixed that issue in [this Contextify commit](https://github.com/brianmcd/contextify/commit/4fc73dfc3583440e298fbc123eb1fdfc71bdf6e3), and pushed a new 0.0.6 release for it.  I updated Zombie to use the new Contextify version.
