### PR TITLE
Fix for #204 (support content-length form-urlencoded)

### DIFF
--- a/lib/zombie/resources.coffee
+++ b/lib/zombie/resources.coffee
@@ -173,9 +173,12 @@ class Resources extends Array
               headers["content-type"] += "; boundary=#{boundary}"
             else
               headers["content-type"] = "text/plain;charset=UTF-8"
+          when "application/x-www-form-urlencoded" 
+            if not headers["Transfer-Encoding"]
+              headers["content-length"] ||= stringify(data).length  
           else
             # Fallback on sending text. (XHR falls-back on this)
-            headers["content-type"] ||= "text/plain;charset=UTF-8"
+            headers["content-type"] ||= "text/plain;charset=UTF-8"        
 
       # Pre 0.3 we need to specify the host name.
       headers["Host"] = url.host


### PR DESCRIPTION
Added content-length for post of form-urlencoded forms (see #204), added tests for existing header, correct content-length and content-length of 0 for empty forms. 
