### PR TITLE
Add double quotes for escaping cookie values with '=' inside

### DIFF
--- a/lib/zombie/cookies.coffee
+++ b/lib/zombie/cookies.coffee
@@ -17,11 +17,12 @@ serialize = (domain, path, name, cookie)->
 deserialize = (serialized)->
   fields = serialized.split(/;+/)
   first = fields[0].trim()
-  if first.split(/\=/).length > 2
+  firstFields = first.split(/\=/)
+  if firstFields.length > 2
       [name, value] = first.split(/\="/)
       value = value.replace(/"$/, '')
   else
-      [name, value] = first.split(/\=/, 2)
+      [name, value] = firstFields
 
   cookie = { name: name, value: value }
   for field in fields


### PR DESCRIPTION
Example:

`foo=0b946b55e588c4d.bar=(baz)` will have it's cookie stored as `foo=0b946b55e588c4d.bar`, but instead if it's quoted with `foo="0b946b55e588c4d.bar=(baz)"` then this will split and remove the double quoted value and set it appropriately.
