### PR TITLE
Support origin in websockets

### DIFF
--- a/lib/zombie/websocket.coffee
+++ b/lib/zombie/websocket.coffee
@@ -1,7 +1,13 @@
 WebSocket = require('websocket-client').WebSocket
 
 exports.use = ->
-	# Add XHR constructor to window.
-	extend = (window)->
-		window.WebSocket = (url, proto, opts) -> new WebSocket(url, proto, opts)
-	return extend: extend
+    # Add WebSocket constructor to window.
+    extend = (window)->
+        window.WebSocket = (url, proto) ->
+            # Make sure that the origin is set correctly
+            loc = window.location
+            opts = origin: loc.protocol + '//' + loc.hostname
+            if window.location.port
+                opts.origin += ':' + window.location.port
+            new WebSocket(url, proto, opts)
+    return extend: extend


### PR DESCRIPTION
I know websockets aren't working on 0.6 at the moment, I intend to fork the websocket client / adapt another one with cleaner handling of the HTTP request.

In the mean-time, this patch adds support for websocket servers which restrict based on origin to zombie.
