### PR TITLE
Replace the dependency for websockets, Re-enable for node > 0.4.

### DIFF
--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -16,8 +16,7 @@ Resources         = require("./resources")
 Storages          = require("./storage")
 URL               = require("url")
 XHR               = require("./xhr")
-if process.version < "v0.5.0"
-  WebSocket       = require("./websocket")
+WebSocket         = require("./websocket")
 
 
 HTML = JSDom.dom.level3.html
@@ -40,7 +39,7 @@ class Browser extends EventEmitter
     @_storages = new Storages()
     @_interact = Interact.use(this)
     @_xhr = XHR.use(@_cache)
-    @_ws = WebSocket.use(this) if WebSocket
+    @_ws = WebSocket.use(this)
     @resources = new Resources(this)
 
     # Make sure we don't blow up Node when we get a JS error, but dump error to console.  Also, catch any errors
@@ -178,7 +177,7 @@ class Browser extends EventEmitter
     @_storages.extend newWindow
     @_interact.extend newWindow
     @_xhr.extend newWindow
-    @_ws.extend newWindow if @_ws
+    @_ws.extend newWindow
     newWindow.screen = new Screen()
     newWindow.JSON = JSON
     newWindow.Image = (width, height)->

--- a/lib/zombie/websocket.coffee
+++ b/lib/zombie/websocket.coffee
@@ -1,13 +1,13 @@
-WebSocket = require("websocket-client").WebSocket
+WebSocket = require("ws")
 
 exports.use = ->
- # Add WebSocket constructor to window.
+  # Add WebSocket constructor to window.
   extend = (window)->
     window.WebSocket = (url, proto) ->
       # Make sure that the origin is set correctly
       loc = window.location
-      opts = { origin: "#{loc.protocol}//#{loc.hostname}" }
+      opts = { origin: "#{loc.protocol}//#{loc.hostname}", protocol: proto }
       if window.location.port
         opts.origin += ":" + window.location.port
-      new WebSocket(url, proto, opts)
+      new WebSocket(url, opts)
   return extend: extend

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "html5":            "~0.3.5",
     "jsdom":            "~0.2.10",
     "mime":             "~1.2.4",
-    "websocket-client": "~1.0.0"
+    "ws":               "~0.3.9"
   },
   "devDependencies": {
     "docco":            "~0.3.0",

--- a/spec/helpers.coffee
+++ b/spec/helpers.coffee
@@ -1,5 +1,6 @@
 DNS       = require("dns")
 Express   = require("express")
+WebSocket = require("ws")
 File      = require("fs")
 Path      = require("path")
 Browser   = require("../lib/zombie.js")
@@ -19,6 +20,7 @@ DNS.lookup = (domain, callback)->
 brains = Express.createServer()
 brains.use Express.bodyParser()
 brains.use Express.cookieParser()
+wss = new WebSocket.Server({ server: brains })
 
 
 brains.get "/", (req, res)->

--- a/spec/websocket_spec.coffee
+++ b/spec/websocket_spec.coffee
@@ -1,47 +1,38 @@
 { Vows, assert, brains, Browser } = require("./helpers")
 
 
-if process.version <= "v0.5.0"
-  Vows.describe("Compatibility with WebSockets").addBatch(
-    "WebSockets":
-      topic: ->
-        brains.get "/ws", (req, res)->
-          res.send """
-          <html>
-            <head>
-              <title>jQuery</title>
-              <script src="/jquery.js"></script>
-            </head>
-            <body>
-              <select>
-                <option>None</option>
-                <option value="1">One</option>
-              </select>
+Vows.describe("Compatibility with WebSockets").addBatch(
+  "WebSockets":
+    topic: ->
+      brains.get "/ws", (req, res)->
+        res.send """
+        <html>
+          <head>
+            <title>jQuery</title>
+            <script src="/jquery.js"></script>
+          </head>
+          <body>
+            <select>
+              <option>None</option>
+              <option value="1">One</option>
+            </select>
+            <span id="ws-url"></span>
+          </body>
+          <script>
+            $(function() {
+              ws = new WebSocket('ws://localhost:3003');
+              $('#ws-url').text(ws.url);
+            });
+          </script>
+        </html>
+        """
+      browser = new Browser
+      browser.wants "http://localhost:3003/ws", @callback
+    "Creating a Websocket":
+      topic: (browser)->
+        browser.text "#ws-url"
+        @callback null, browser
+      "should be possible": (browser)->
+        assert.equal browser.text("#ws-url"), "ws://localhost:3003"
 
-              <span id="ws"></span>
-
-              <a href="#post">Post</a>
-
-              <div id="response"></div>
-            </body>
-
-            <script>
-              $(function() {
-
-              ws = new WebSocket('ws://localhost/some/url');
-              $('#ws').text(ws.url);
-
-              });
-            </script>
-          </html>
-          """
-        browser = new Browser
-        browser.wants "http://localhost:3003/ws", @callback
-      "Creating a Websocket":
-        topic: (browser)->
-          browser.text "#ws"
-          @callback null, browser
-        "should be possible": (browser)->
-          assert.equal browser.text("#ws"), "ws://localhost/some/url"
-
-  ).export(module)
+).export(module)


### PR DESCRIPTION
Changed the library used for providing websockets from `websocket-client` to `ws` package, which is maintained. Remove the code excluding websockets from running with node versions after 0.4. Include a websocket server in the test helpers. Tests pass :)

Thanks!
