### PR TITLE
Added a test for jQuery.globalEval()

### DIFF
--- a/spec/jquery_compat.coffee
+++ b/spec/jquery_compat.coffee
@@ -66,4 +66,10 @@ for version in JQUERY_VERSIONS
         "should perform an AJAX POST request": (browser)->
           assert.match browser.text("#response"), /foo=bar/
 
+      "jQuery.globalEval": (browser) ->
+          browser.evaluate("(function () {
+            $.globalEval('var globalEvalWorks = true;');
+          })();")
+          assert.ok browser.window.globalEvalWorks
+
 Vows.describe("Compatibility with jQuery").addBatch(batch).export(module)


### PR DESCRIPTION
This currently fails, but with a soon-to-be-updated Contextify it passes.  I've never used vows, so hopefully this is the right way to do things.

I also noticed that `make test` does `vows --spec spec/*_spec.coffee`, which skips spec/css.coffee and spec/jquery_compat.coffee.  Is this intentional?  The test in this pull request only runs if you run it manually.  I didn't want to change the file names to add _spec in case there's a reason it's set up that way.

I will do a few more Contextify tweaks, then push a new version tonight which fixes this test.
