### PR TITLE
Fix browser.site so that it supports file:/ url scheme

### DIFF
--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -387,7 +387,7 @@ class Browser extends EventEmitter
       [duration, options] = [options, null]
     @withOptions options, (reset_options)=>
       if site = @site
-        site = "http://#{site}" unless /^https?:/i.test(site)
+        site = "http://#{site}" unless /^(https?:|file:)/i.test(site)
         url = URL.resolve(site, URL.parse(URL.format(url)))
       @window.history._assign url
       if callback

--- a/spec/browser_spec.coffee
+++ b/spec/browser_spec.coffee
@@ -194,6 +194,15 @@ Vows.describe("Browser").addBatch
       teardown: ->
         Browser.site = null
 
+    "global with file: url scheme":
+      topic: ->
+        Browser.site = "file://" + __dirname + "/data/";
+        browser = new Browser;
+        browser.wants "index.html", @callback
+      "should set the browser options from global options": (browser)->
+        assert.equal browser.site, "file://" + __dirname + "/data/";
+        assert.match browser.document.title, /Insanely fast, headless/
+
   "user agent":
     topic: ->
       brains.get "/browser/useragent", (req, res)->


### PR DESCRIPTION
if I run:

browser.site = "file:///some/file/path/";
browser.visit("index.html");

!== It fails, because it resolves the path to be "http://file:///some/file/path/index.html"

Zombie should support file:// urls as first-class citizens, no? 
