### PR TITLE
Enable stubbing of resources with pre-canned responses

### DIFF
--- a/spec/resources_spec.coffee
+++ b/spec/resources_spec.coffee
@@ -42,5 +42,25 @@ Vows.describe("Resources").addBatch
         catch e
           assert.ok false, "calling dump method throws an error [" + e + "]"
 
+  "Browsing content referencing a stubbed resource":
+    topic: ->
+      brains.get "/stubberoo", (req, res)->
+        res.send """
+        <html>
+          <head><script src="http://fa.ke/url.js"></script></head>
+          <body></body>
+        </html>
+        """
+
+    "should load it":
+      topic: ->
+        brains.ready =>
+          browser = new Browser
+          request = {url:"http://fa.ke/url.js"}
+          response = {body:'console.log("stubbed script");'}
+          browser.resources.stubRequest(request, response);
+          browser.visit "http://localhost:3003/stubberoo", @callback
+      "should have loaded stubbed resource": (browser)->
+        assert.equal browser.window.console.output, "stubbed script\n"
 
 .export(module)


### PR DESCRIPTION
I use zombie for testing some node apps. In certain cases I don't want the page to actually fetch the real remote  resource (FB initialization scripts, for example) - but I want to load something else. This patch enables it. Here's the usage:

```
browser = new Browser
request = {url:"http://fa.ke/url.js"}
response = {body:'console.log("stubbed script");'}
browser.resources.stubRequest(request, response);
```
