### PR TITLE
* Support for <script type="text/coffeescript">.

### DIFF
--- a/lib/zombie/jsdom_patches.coffee
+++ b/lib/zombie/jsdom_patches.coffee
@@ -55,6 +55,8 @@ HTML.Document.prototype._elementBuilders["iframe"] = (doc, s)->
       iframe.window.location.href = url
   return iframe
 
+HTML.languageProcessors.coffeescript = (element, code, filename)->
+  @javascript(element, require('coffee-script').compile(code), filename)
 
 # If JSDOM encounters a JS error, it fires on the element.  We expect it to be
 # fires on the Window.  We also want better stack traces.


### PR DESCRIPTION
This is because the client-side "coffee-script.js" doesn't seem
  to find those tags, so we'd need to handle CoffeeScript inclusions
  by ourselves.
