### PR TITLE
Added a failing test for mixed forms ( forms with input and upload field )

### DIFF
--- a/spec/forms_spec.coffee
+++ b/spec/forms_spec.coffee
@@ -563,6 +563,12 @@ Vows.describe("Forms").addBatch(
               <input name="get_file" type="file">
               <input type="submit" value="Get Upload">
             </form>
+
+            <form method="post" enctype="multipart/form-data">
+              <input name="username" type="text">
+              <input name="logfile" type="file">
+              <button>Save</button>
+            </form>
           </body>
         </html>
         """
@@ -605,6 +611,19 @@ Vows.describe("Forms").addBatch(
         "should upload file": (browser)->
           digest = Crypto.createHash("md5").update(File.readFileSync(@filename)).digest("hex")
           assert.equal browser.text("body").trim(), digest
+
+    "mixed":
+      Browser.wants "http://localhost:3003/forms/upload"
+        topic: (browser)->
+          filename = __dirname + "/data/random.txt"
+          browser
+            .fill('username', 'hello')
+            .attach("logfile", filename)
+            .pressButton "Save", @callback
+        "should upload file": (browser)->
+          assert.equal browser.text("body").trim(), "Random text"
+        "should upload include name": (browser)->
+          assert.equal browser.text("title"), "random.txt"
 
     "empty":
       Browser.wants "http://localhost:3003/forms/upload"


### PR DESCRIPTION
When attaching a file and filling in a field you get the following error:

```
Error: parser error, 2 of 35 bytes parsed
    at IncomingForm.write (/home/fs/work/zombie/node_modules/express/node_modules/connect/node_modules/formidable/lib/incoming_form.js:141:17)
    at IncomingMessage.<anonymous> (/home/fs/work/zombie/node_modules/express/node_modules/connect/node_modules/formidable/lib/incoming_form.js:91:12)
    at IncomingMessage.<anonymous> (events.js:67:17)
    at IncomingMessage.emit (/home/fs/work/zombie/node_modules/vows/lib/vows.js:236:24)
    at HTTPParser.onBody (http.js:115:23)
    at Socket.ondata (http.js:1387:22)
    at TCP.onread (net.js:354:27)
```

This is my first pull request I hope I didn't do anything weird.
