### PR TITLE
Force JSDom version to 2.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "coffee-script":    "~1.2",
-    "jsdom":            "~0.2.10",
+    "jsdom":            "0.2.10",
     "mime":             "~1.2.4",
     "ws":               "~0.4.0"
   },


### PR DESCRIPTION
The upgrade from jsdom 2.0.10 to 2.0.11 is a breaking change. Temporarily force the version until a fix is found.
