### PR TITLE
Fixes script loading for scripts with file uri scheme src

### DIFF
--- a/lib/zombie/jsdom_patches.coffee
+++ b/lib/zombie/jsdom_patches.coffee
@@ -32,11 +32,13 @@ HTML.resourceLoader.load = (element, href, callback)->
         element.window.location = URL.resolve(element.window.parent.location, href)
       else
         url = URL.parse(@resolve(document, href))
-        loaded = (response, filename)->
-          callback.call this, response.body, URL.parse(response.url).pathname
         if url.hostname
+          loaded = (response, filename)->
+            callback.call this, response.body, URL.parse(response.url).pathname
           window.browser.resources.get url, @enqueue(element, loaded, url.pathname)
         else
+          loaded = (data, filename)->
+            callback.call this, data, filename
           file = @resolve(document, url.pathname)
           @readFile file, @enqueue(element, loaded, file)
 

--- a/spec/data/file_scheme.html
+++ b/spec/data/file_scheme.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>JS should change me</title>
+    <script type="text/javascript" src="file_scheme.js"></script>
+  </head>
+  <body>
+    <p>This fixture is used to test scripts loaded via a file uri scheme.</p>
+  </body>
+</html>

--- a/spec/data/file_scheme.js
+++ b/spec/data/file_scheme.js
@@ -1,0 +1,1 @@
+document.title = "file://";

--- a/spec/script_spec.coffee
+++ b/spec/script_spec.coffee
@@ -308,6 +308,14 @@ Vows.describe("Scripts").addBatch
     "should not run scripts": (browser)->
       assert.equal browser.document.title, "Zero"
 
+.addBatch
+
+  "file:// uri scheme":
+    Browser.wants "file://" + __dirname + "/data/file_scheme.html"
+      topic: (browser)->
+        browser.wait 100, @callback
+      "should run scripts with file url src": (browser)->
+        assert.equal browser.document.title, "file://"
 
   ###
 .addBatch


### PR DESCRIPTION
I ran into this bug trying to run headless unit tests in a local HTML page that I access with the file:// scheme. Looks to be the same bug discussed in issue #247.
