### PR TITLE
Add windowName option.

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -41,6 +41,7 @@ You can use the following options:
 - `silent` -- If true, supress all `console.log` output from scripts.  You can still view it with `window.console.output`.
 - `site` -- Base URL for all requests.  If set, you can call `visit` with relative URL.
 - `waitFor` -- Tells `wait` function how long to wait (in milliseconds) while timers fire.  Defaults to 0.5 seconds.
+- `windowName` -- Sets the browser's window.name property; useful when an evaluated script tries to detect whether/where the window is embedded as an iframe. Defaults to "nodejs".
 
 Credential options look like this:
 

--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -20,7 +20,7 @@ WebSocket         = require("./websocket")
 
 HTML = JSDom.dom.level3.html
 MOUSE_EVENT_NAMES = ["mousedown", "mousemove", "mouseup"]
-BROWSER_OPTIONS   = ["credentials", "debug", "htmlParser", "loadCSS", "referer", "runScripts", "silent", "site", "userAgent", "waitFor"]
+BROWSER_OPTIONS   = ["credentials", "debug", "htmlParser", "loadCSS", "referer", "runScripts", "silent", "site", "userAgent", "waitFor", "windowName"]
 
 
 PACKAGE = JSON.parse(require("fs").readFileSync(__dirname + "/../../package.json"))
@@ -93,6 +93,9 @@ class Browser extends EventEmitter
 
     # Tells `wait` and any function that uses `wait` how long to wait for, executing timers.  Defaults to 0.5 seconds.
     @waitFor = 500
+
+    # You can set the browser window.name property
+    @windowName = "nodejs"
 
     # Sets the browser options.
     for name in BROWSER_OPTIONS
@@ -171,6 +174,7 @@ class Browser extends EventEmitter
     newWindow.navigator.javaEnabled = ->
       return false
     newWindow.navigator.userAgent = @userAgent
+    newWindow.name = @windowName
     
     @_cookies.extend newWindow
     @_storages.extend newWindow


### PR DESCRIPTION
Adds an option for setting the browser's window.name property. Useful when an evaluated script tries to detect whether/where the window is embedded as an iframe. Defaults to "nodejs".
