### PR TITLE
Updated: Remove 'Content Type' and 'Content Length' from headers on redirect when previous HTTP method was either a POST or PUT

### DIFF
--- a/lib/zombie/resources.coffee
+++ b/lib/zombie/resources.coffee
@@ -233,6 +233,9 @@ class Resources extends Array
                 error = new Error("Too many redirects, from #{URL.format(url)} to #{redirect}")
               else
                 process.nextTick =>
+                  if method in ["POST", "PUT"]
+                    delete headers['content-type']
+                    delete headers['content-length']
                   @_makeRequest "GET", redirect, null, headers, resource, callback
             else
               error = new Error("Redirect with no Location header, cannot follow")


### PR DESCRIPTION
_Removes extra commit_

This pull request ensures that we delete the the 'Content Length' and 'Content Type' from the headers on a redirect when the previous (request) HTTP method was either a POST or a PUT. 

Rationale:
- The redirect is always a GET which means form content types (application/x-www-form-url-encoded, multipart) are invalid
- This was causing Google's OAuth authentication to fail after the user had been authenticated and _redirected_ to the authorization page

Potential pitfalls
- I couldn't find test suite that tested redirects -- I'm inclined to delegate this for now
- The headers object is being modified and passed to other methods. Optimally, we should treat this like an immutable data structure and copy then modify
- My placement of the deletion may not be necessary in the nextTick callback
