### PR TITLE
HTTP Proxy support with basic auth

### DIFF
--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -20,7 +20,7 @@ WebSocket         = require("./websocket")
 
 HTML = JSDom.dom.level3.html
 MOUSE_EVENT_NAMES = ["mousedown", "mousemove", "mouseup"]
-BROWSER_OPTIONS   = ["credentials", "proxy", "debug", "htmlParser", "loadCSS", "referer", "runScripts", "silent", "site", "userAgent", "waitFor"]
+BROWSER_OPTIONS   = ["credentials", "proxy", "debug", "htmlParser", "loadCSS", "referer", "runScripts", "silent", "site", "userAgent", "waitFor", "windowName"]
 
 
 PACKAGE = JSON.parse(require("fs").readFileSync(__dirname + "/../../package.json"))
@@ -74,7 +74,7 @@ class Browser extends EventEmitter
     # add proxy to browser.vist
     @proxy = false
 
-    # Which parser to use (HTML5 by default). For example:
+	# Which parser to use (HTML5 by default). For example:
     #   zombie.htmlParser = require("html5").HTML5
     @htmlParser = null
 
@@ -98,6 +98,9 @@ class Browser extends EventEmitter
 
     # Tells `wait` and any function that uses `wait` how long to wait for, executing timers.  Defaults to 0.5 seconds.
     @waitFor = 500
+
+    # You can set the browser window.name property
+    @windowName = "nodejs"
 
     # Sets the browser options.
     for name in BROWSER_OPTIONS
@@ -176,6 +179,7 @@ class Browser extends EventEmitter
     newWindow.navigator.javaEnabled = ->
       return false
     newWindow.navigator.userAgent = @userAgent
+    newWindow.name = @windowName
     
     @_cookies.extend newWindow
     @_storages.extend newWindow
@@ -258,7 +262,8 @@ class Browser extends EventEmitter
   queryAll: (selector, context)->
     context ||= @document
     if selector
-      return context.querySelectorAll(selector).toArray()
+      ret = context.querySelectorAll(selector)
+      return Array.prototype.slice.call(ret, 0)
     else
       return [context]
 
@@ -559,7 +564,7 @@ class Browser extends EventEmitter
   # Without callback, returns this.
   choose: (selector, callback)->
     field = @field(selector) || @field("input[type=radio][value=\"#{escape(selector)}\"]")
-    if field && field.tagName == "INPUT" && field.type == "radio" && field.form
+    if field && field.tagName == "INPUT" && field.type == "radio"
       field.click()
       if callback
         @wait callback

--- a/lib/zombie/history.coffee
+++ b/lib/zombie/history.coffee
@@ -109,8 +109,8 @@ class History
         when "oauth"
           headers["authorization"] = "OAuth #{credentials.token}"
         when "proxy-basic"
-            base64 = new Buffer(credentials.user + ":" + credentials.password).toString("base64")
-            headers["Proxy-Authorization"] = "Basic #{base64}"
+          base64 = new Buffer(credentials.user + ":" + credentials.password).toString("base64")
+          headers["Proxy-Authorization"] = "Basic #{base64}"
 
     @_browser.resources.request method, url, data, headers, (error, response)=>
       if error

--- a/lib/zombie/resources.coffee
+++ b/lib/zombie/resources.coffee
@@ -207,14 +207,14 @@ class Resources extends Array
       host = @_browser.proxy.host
       port = @_browser.proxy.port
       path = "#{url.protocol}//#{url.host}#{url.pathname}#{url.search || ""}"
-    
+
     # First request has not resource, so create it and add to
     # Resources.  After redirect, we have a resource we're using.
     unless resource
       resource = new Resource(new HTTPRequest(method, url, headers, null))
       this.push resource
     @_browser.log -> "#{method} #{URL.format(url)}"
-    
+
     request =
       host: host
       port: port


### PR DESCRIPTION
I made this fix based in some code of https://github.com/chayim/zombie/commit/10e6082f472940cd9006bff586d7a041afae1d2c

But as it was not working (at least for me) I modified the code to make it work.
I've tested it either with and without proxies (both using auth and w/o authentication) and its working fine.

How to use it?

var options = {credentials : { 'scheme' : 'proxy-basic', user: 'proxy_username', password: 'proxy_password' }, proxy:  { host : 'proxy.address' , port : proxy_port }};
var b = new Browser(options);

b.visit('http://domain.tld/', function (e, b) {
});

Feel free to send me comments/feedback about it, hope it work for every people who was waiting for this,

Thanks!
