### PR TITLE
Fix test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "html", "html5", "dom", "css", "javascript", "integration", "ajax", "full-stack", "DSL" ],
   "main": "lib/zombie",
   "scripts": {
-    "test":   "mocha"
+    "test":   "./node_modules/.bin/mocha"
   },
   "engines": {
     "node": ">= 0.6.0"


### PR DESCRIPTION
`"test": "moch"` requires mocha installed in global.(`npm install -g mocha`)
It couldn't specify the mocha version defined in `package.json`.

Instead, use local mocha when run `npm test`.
