### PR TITLE
Add 'coffee-script' to 'dependencies' at package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "node": ">= 0.6.0"
   },
   "dependencies": {
+    "coffee-script":    "~1.3.1",
     "eventsource":      "~0.0.5",
     "htmlparser":       "~1.7.6",
     "html5":            "~0.3.5",
@@ -30,7 +31,6 @@
     "ws":               "~0.4.14"
   },
   "devDependencies": {
-    "coffee-script":    "~1.3.1",
     "docco":            "~0.3.0",
     "express":          "~2.5.9",
     "highlight":        "~0.2.2",


### PR DESCRIPTION
The npm module 'coffee-script' is requied
to compile client-side coffee-script.
