### PR TITLE
Added closed property to window

### DIFF
--- a/lib/zombie/windows.coffee
+++ b/lib/zombie/windows.coffee
@@ -90,6 +90,9 @@ class Windows
     index = @_stack.indexOf(window)
     return unless index >= 0
   
+    # Set `window`'s `closed` property to `true`
+    window.closed = true
+
     delete @_named[window.name]
     @_stack.splice(index, 1)
     # If we closed the currently open window, switch to the previous window.
@@ -141,6 +144,9 @@ class Windows
         return @document.title
       set: (title)->
         @document.title = title
+
+    # `window`s have a `closed` property defaulting to `false`
+    window.closed = false
 
     # javaEnabled, present in browsers, not in spec Used by Google Analytics see
     # https://developer.mozilla.org/en/DOM/window.navigator.javaEnabled

--- a/test/browser_test.coffee
+++ b/test/browser_test.coffee
@@ -424,6 +424,9 @@ describe "Browser", ->
       it "should set window name", ->
         assert.equal window.name, "popup"
 
+      it "should set window closed to false", ->
+        assert.equal window.closed, false
+
       it "should load page", ->
         assert.equal window.document.querySelector("h1").textContent, "Popup window"
 
@@ -471,13 +474,18 @@ describe "Browser", ->
 
 
       describe "and close it", ->
+        closed_window = null
         before ->
+          closed_window = browser.window
           browser.window.close()
 
         it "should lose that window", ->
           assert.equal browser.windows.all().length, 1
           assert.equal browser.windows.get(0).name, "nodejs"
           assert !browser.windows.get(1)
+
+        it "should set the `closed` property to `true`", ->
+          assert.equal closed_window.closed, true
 
         it "should switch to last window", ->
           assert.equal browser.window, browser.windows.get(0)


### PR DESCRIPTION
Useful for Facebook and other scripts that open popups and then set an interval to check if the window is `closed` to call some other function.
