### PR TITLE
Check for already valid HTML element in browser.link and browser.button methods

### DIFF
--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -418,6 +418,9 @@ class Browser extends EventEmitter
   #
   # Finds and returns a link by its text content or selector.
   link: (selector)->
+    # If the link has already been queried, return itself
+    if selector instanceof HTML.Element
+      return selector
     if link = @querySelector(selector)
       return link if link.tagName == "A"
     for link in @querySelectorAll("body a")
@@ -703,6 +706,9 @@ class Browser extends EventEmitter
   #
   # selector - CSS selector, button name or text of BUTTON element
   button: (selector)->
+    # If the button has already been queried, return itself
+    if selector instanceof HTML.Element
+      return selector
     if button = @querySelector(selector)
       return button if button.tagName == "BUTTON" || button.tagName == "INPUT"
     for button in @querySelectorAll("button")

--- a/test/selection_test.coffee
+++ b/test/selection_test.coffee
@@ -105,6 +105,23 @@ describe "Selection", ->
     it "should combine multiple elements", ->
       assert.equal @browser.html("title, #main a"), "<title>The Living</title><a href=\"/browser/dead\">Kill</a>"
 
+  describe "button", ->
+    describe "when passed a valid HTML element", ->
+      it "should return the already queried element", ->
+        elem = @browser.querySelector "button:first"
+        assert.equal @browser.button(elem), elem
+
+  describe "link", ->
+    describe "when passed a valid HTML element", ->
+      it "should return the already queried element", ->
+        elem = @browser.querySelector "a:first"
+        assert.equal @browser.link(elem), elem
+
+  describe "field", ->
+    describe "when passed a valid HTML element", ->
+      it "should return the already queried element", ->
+        elem = @browser.querySelector "input[name='email']"
+        assert.equal @browser.field(elem), elem
 
   describe "jQuery", ->
     before ->


### PR DESCRIPTION
The helper methods invoked by `pressButton` and `clickLink` weren't checking to see if the selector passed to them was already a valid HTML element. This manifested itself for me when trying to invoke `pressButton` with an element I'd already queried from an iframe - the `browser.button` helper method returns nothing and hence `pressButton` throws an error.

I've simply re-used the logic already present in `browser.field` to fix this, and added some tests to cover this behaviour (including one for `browser.field` while I was at it). Not 100% convinced the tests are in the right place but it was the best fit I could find.

These fixes enabled me to test link and button submissions from within iFrames.
