### PR TITLE
Add support for jsdom a.hostname property until jsdom 0.2.15

### DIFF
--- a/lib/zombie/jsdom_patches.coffee
+++ b/lib/zombie/jsdom_patches.coffee
@@ -52,6 +52,11 @@ HTML.HTMLAnchorElement.prototype.__defineGetter__ "href", ->
 HTML.HTMLLinkElement.prototype.__defineGetter__ "href", ->
   return HTML.resourceLoader.resolve(@_ownerDocument, @getAttribute('href') || "")
 
+# this patch is required for jsdom < 0.2.15
+HTML.HTMLAnchorElement.prototype.__defineGetter__ "hostname", ->
+  return URL.parse(@getAttribute('href') || "").hostname
+
+
 # These properties return empty string when attribute is not set.
 HTML.HTMLElement.prototype.__defineGetter__ "id", ->
   return @getAttribute("id") || ""


### PR DESCRIPTION
a dom elements should have a hostname property. jsdom does not have it as of 0.2.14, added issue https://github.com/tmpvar/jsdom/issues/257 and pull request https://github.com/tmpvar/jsdom/pull/463

This patches jsdom until such time as it is unnecessary.
