### PR TITLE
support for browser custom headers

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -52,6 +52,9 @@ You can use the following options:
 - `windowName` -- Sets the browser's window.name property; useful when an
   evaluated script tries to detect whether/where the window is embedded as an
   iframe. Defaults to "nodejs".
+- `customHeaders` -- Additional HTTP headers to be sent with each browser
+  request. Override any header previously set. Format is { header: value, ... }.
+  Defaults to {}.
 
 The proxy URL specifies the host and port of the proxy.  It also supports HTTP
 Basic authentication, for example:

--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -24,11 +24,11 @@ XHR               = require("./xhr")
 # Browser options you can set when creating new browser, or on browser instance.
 BROWSER_OPTIONS = ["debug", "htmlParser", "loadCSS", "maxWait", "proxy",
                    "referer", "runScripts", "silent", "site", "userAgent",
-                   "waitFor", "name"]
+                   "waitFor", "name", "customHeaders"]
 
 # Global options you can set on Browser and will be inherited by each new browser.
 GLOBAL_OPTIONS  = ["debug", "htmlParser", "loadCSS", "maxWait", "proxy", "runScripts",
-                   "silent", "site", "userAgent", "waitFor"]
+                   "silent", "site", "userAgent", "waitFor", "customHeaders"]
 
 
 PACKAGE = JSON.parse(require("fs").readFileSync(__dirname + "/../../package.json"))
@@ -120,6 +120,8 @@ class Browser extends EventEmitter
   # Tells `wait` and any function that uses `wait` how long to wait for, executing timers.  Defaults to 0.5 seconds.
   @waitFor: "0.5s"
 
+  # Additional headers to be sent with each HTTP request
+  @customHeaders: {}
 
   # Changes the browser options, and calls the function with a callback (reset).  When you're done processing, call the
   # reset function to bring options back to their previous values.

--- a/lib/zombie/resources.coffee
+++ b/lib/zombie/resources.coffee
@@ -246,6 +246,10 @@ class Resources extends Array
     # We only use the JAR for response cookies
     jar = Request.jar()
 
+    # Merge custom headers
+    for name, value of browser.customHeaders
+      headers[name] = value
+
     params = 
       method:         method
       url:            url

--- a/test/browser_test.coffee
+++ b/test/browser_test.coffee
@@ -239,6 +239,22 @@ describe "Browser", ->
         it "should be accessible from navigator", ->
           assert.equal @browser.window.navigator.userAgent, "imposter"
 
+    describe "custom headers", ->
+
+      before (done)->
+        brains.get "/browser/custom_headers", (req, res)->
+          res.send "<html><body>#{req.headers["x-custom-header"]}</body></html>"
+        brains.ready done
+
+      describe "specified", ->
+
+        before (done)->
+          @browser = new Browser()
+          @browser.customHeaders = "x-custom-header": "dummy"
+          @browser.visit "http://localhost:3003/browser/custom_headers", done
+
+        it "should send the custom header to server", ->
+          assert.equal @browser.text("body"), "dummy"
 
   describe "click link", ->
 


### PR DESCRIPTION
This is a basic implementation of custom headers to be sent with each browser request. I needed this to send custom authentication headers. Found this link saying it was not implemented https://groups.google.com/forum/?fromgroups#!topic/zombie-js/l4EAgBFvTRM and found no mention in current code or documentation.

See you
Federico
