### PR TITLE
Fixes test suite on ubuntu

### DIFF
--- a/test/history_test.coffee
+++ b/test/history_test.coffee
@@ -5,8 +5,6 @@ URL   = require("url")
 
 describe "History", ->
 
-  # On OS X path probably starts with /Users, but as URL the first component
-  # ends up as the hostname (stupid), which gets lowered case to /user.
   file_url = "file://#{__dirname}/data/index.html"
 
 


### PR DESCRIPTION
Lowercasing the directory path make tests fail under ubuntu when path contains uppercase characters.
