### PR TITLE
emit JS errors as 'error' event on Browser object

### DIFF
--- a/lib/zombie/scripts.coffee
+++ b/lib/zombie/scripts.coffee
@@ -89,6 +89,7 @@ raise = ({ element, location, from, scope, error })->
   event.message = error.message
   event.error = error
   window.dispatchEvent event
+  element.ownerDocument.parentWindow.browser.emit('error', error)
   return
 
 


### PR DESCRIPTION
Either this change should be taken, or an alternative method implemented.  Not getting at JS errors easily was a major debugging headache for me!
