### PR TITLE
expose max redirects as a browser option

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -40,6 +40,7 @@ You can use the following options:
 - `loadCSS` -- Loads external stylesheets.  Defaults to true.
 - `maxWait` -- Maximum wait time (when calling `visit`, `wait`, etc).  Defaults
   to 5 seconds.
+- `maxRedirects` -- Tells the browser how many redirects to follow before aborting a request. Defaults to 5
 - `proxy` -- Proxy URL.
 - `runScripts` -- Run scripts included in or loaded from the page.  Defaults to
   true.

--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -24,11 +24,11 @@ XHR               = require("./xhr")
 # Browser options you can set when creating new browser, or on browser instance.
 BROWSER_OPTIONS = ["debug", "headers", "htmlParser", "loadCSS", "maxWait", "proxy",
                    "referer", "runScripts", "silent", "site", "userAgent",
-                   "waitFor", "name"]
+                   "waitFor", "name", "maxRedirects"]
 
 # Global options you can set on Browser and will be inherited by each new browser.
 GLOBAL_OPTIONS  = ["debug", "headers", "htmlParser", "loadCSS", "maxWait", "proxy",
-                   "runScripts", "silent", "site", "userAgent", "waitFor"]
+                   "runScripts", "silent", "site", "userAgent", "waitFor", "maxRedirects"]
 
 
 PACKAGE = JSON.parse(require("fs").readFileSync(__dirname + "/../../package.json"))
@@ -119,6 +119,9 @@ class Browser extends EventEmitter
 
   # Tells `wait` and any function that uses `wait` how long to wait for, executing timers.  Defaults to 0.5 seconds.
   @waitFor: "0.5s"
+  
+  # Tells the browser how many redirects to follow before aborting a request. Defaults to 5
+  @maxRedirects: 5
 
   # Additional headers to be sent with each HTTP request
   @headers: {}

--- a/lib/zombie/resources.coffee
+++ b/lib/zombie/resources.coffee
@@ -285,8 +285,8 @@ class Resources extends Array
       if redirect
         # Handle redirection, make sure we're not caught in an infinite loop
         ++resource.redirects
-        if resource.redirects > 5
-          callback new Error("More than five redirects, giving up")
+        if resource.redirects > browser.maxRedirects
+          callback new Error("More than " + browser.maxRedirects + " redirects, giving up")
           return
 
         # This URL is the referer, make a request to the next URL


### PR DESCRIPTION
While 5 redirects is fine most of the time, I have a case where I need to follow more than 5 redirects.  This commit exposes a `maxRedirects` option.
