### PR TITLE
Update lib/zombie/browser.coffee

### DIFF
--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -756,7 +756,7 @@ class Browser extends EventEmitter
   #
   # Returns the element in focus.
   focused: ->
-    return @window._focused
+    return @window.document._focused
 
 
   # Cookies and storage


### PR DESCRIPTION
_focused is stored in the document, not window. 
BTW: _focused is not triggered for textareas, still to be fixed
