### PR TITLE
Do not browse content-type we are not able to parse

### DIFF
--- a/lib/zombie/history.coffee
+++ b/lib/zombie/history.coffee
@@ -111,6 +111,9 @@ class History
             document.write error.message
             document.close()
             @_browser.emit "error", error
+          else if response.statusCode < 400 and response.headers['content-type'] and response.headers['content-type'].indexOf('text/html') is -1
+            # we're not smart enough to process the content and generate an HTML DOM tree from it.
+            @_browser.emit "error", new Error("Could not parse document at #{URL.format(url)}")
           else
             document = @_createDocument(@_window, response.url)
             @_browser.response = [response.statusCode, response.headers, response.body]
@@ -128,8 +131,7 @@ class History
               evt.initEvent "hashchange", true, false
               @_browser.dispatchEvent @_window, evt
 
-            # Error on any response that's not 2xx, or if we're not smart enough to
-            # process the content and generate an HTML DOM tree from it.
+            # Error on any response that's not 2xx
             if response.statusCode >= 400
               @_browser.emit "error", new Error("Server returned status code #{response.statusCode}")
             else if document.documentElement


### PR DESCRIPTION
Hi, 

The following exemple fails very badly, because zombie try to parse an image : 

```
[romain@myhost zombie]$ cat exemple.js 
var Browser = require("./");
var assert = require("assert");

// Load the page from localhost
browser = new Browser()
browser.visit("http://tylkomrok.pl/wp-content/uploads/2011/01/zombimo_happy_face_zombie.jpg", function () {
  console.log('loaded')
});
```

Here is the output

```
[romain@myhost zombie]$ node exemple.js 
Can't create element 'b�p�$҈�<�r��q�uro�tz��w(#����������9����њ"�h��' (Error: Invalid character: Invalid character in tag name: �) Using a div for now. FIXME!
Can't set attribute 'j�d����n�;���֞' to value '': (Error: Invalid character: attribute name: j�d����n�;���֞)
Can't set attribute '��gw' to value '': (Error: Invalid character: attribute name: ��gw)
Can't set attribute 'g@����8����e0zuv���d�g+?����v)�+##qњ"�e���(���(���(���(���(���cζ���%��(���(���(������z"�n)8��le��^c-6�%����2o*�{r�ce��������f' to value '': (Error: Invalid character: attribute name: g@����8����e0zuv���d�g+?����v)�+##qњ"�e���(���(���(���(���(���cζ���%��(���(���(������z"�n)8��le��^c-6�%����2o*�{r�ce��������f)
Can't create element 'o��[�o�m�$g' (Error: Invalid character: Invalid character in tag name: ��[�) Using a div for now. FIXME!
```

This PR warns the user that the document could not be parsed, but zombie do not crash.

<!---
@huboard:{"order":362.0}
-->
