### PR TITLE
localStorage.getItem should return null

### DIFF
--- a/lib/zombie/storage.coffee
+++ b/lib/zombie/storage.coffee
@@ -34,7 +34,7 @@ class StorageArea
 
   # Get value from key
   get: (key)->
-    return @_items[key]
+    return @_items[key] || null
 
   # Set the value of a key. We also need the source storage (so we don't send
   # it a storage event).

--- a/test/storage_test.coffee
+++ b/test/storage_test.coffee
@@ -13,7 +13,7 @@ test = (scope)->
     it "should handle key() with no key", ->
       assert !@storage.key(1)
     it "should handle getItem() with no item", ->
-      it assert !@storage.getItem("nosuch")
+      assert.equal @storage.getItem("nosuch"), null
     it "should handle removeItem() with no item", ->
       assert.doesNotThrow =>
         @storage.removeItem("nosuch")
@@ -75,7 +75,7 @@ test = (scope)->
       assert.equal @storage.key(0), "wants"
       assert !@storage.key(1)
     it "should forget value", ->
-      assert !@storage.getItem("is")
+      assert.equal @storage.getItem("is"), null
       assert.equal @storage.getItem("wants"), "brains"
 
 
@@ -93,8 +93,8 @@ test = (scope)->
     it "should forget all keys", ->
       assert !@storage.key(0)
     it "should forget all values", ->
-      assert !@storage.getItem("is")
-      assert !@storage.getItem("wants")
+      assert.equal @storage.getItem("is"), null
+      assert.equal @storage.getItem("wants"), null
 
 
   describe "store null", ->


### PR DESCRIPTION
localStorage.getItem should return null, instead of undefined (see http://dev.w3.org/html5/webstorage/#dom-storage-getitem),  so it breaks some libs that explicitly check return value for null
