### PR TITLE
Fixing some of the browser documentation

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -38,7 +38,7 @@ You can use the following options:
   environment variable `DEBUG` is set.
 - `headers` -- Additional HTTP headers to be sent with each browser request.
 - `loadCSS` -- Loads external stylesheets.  Defaults to true.
-- `maxWait` -- Maximum wait time (when calling `visit`, `wait`, etc).  Defaults
+- `waitDuration` -- Maximum wait time (when calling `visit`, `wait`, etc).  Defaults
   to 5 seconds.
 - `maxRedirects` -- Tells the browser how many redirects to follow before aborting a request. Defaults to 5
 - `proxy` -- Proxy URL.
@@ -49,8 +49,6 @@ You can use the following options:
   still view it with `window.console.output`.
 - `site` -- Base URL for all requests.  If set, you can call `visit` with
   relative URL.
-- `waitFor` -- Tells `wait` function how long to wait (in milliseconds) while
-  timers fire.  Defaults to 0.5 seconds.
 
 The proxy URL specifies the host and port of the proxy.  It also supports HTTP
 Basic authentication, for example:


### PR DESCRIPTION
I was trying to change the maxWait for a browser but after looking at the code it seems like maxWait has been renamed and waitFor has been removed. This commit just fixes that in the API documentation. 

Renamed maxWait to waitDuration as per: https://github.com/assaf/zombie/blob/7bb131f34c25ed72926ac2ac74e3e1f23788d8f5/lib/zombie/browser.coffee
Removed waitFor because it no longer works and is no longer in the Browser class
