### PR TITLE
small documentation fix

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -567,7 +567,7 @@ of the many methods that accept a callback.
 In addition the browser is also an `EventEmitter`.  You can register any number
 of event listeners to any of the emitted events.
 
-### browser.fire(name, target, calback?)
+### browser.fire(target, name, calback?)
 
 Fires a DOM event.  You can use this to simulate a DOM event, e.g. clicking a
 link or clicking the mouse.  These events will bubble up and can be cancelled.

--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -296,8 +296,8 @@ class Browser extends EventEmitter
   # Fire a DOM event.  You can use this to simulate a DOM event, e.g. clicking a link.  These events will bubble up and
   # can be cancelled.  Like `wait` this method either takes a callback or returns a promise.
   #
-  # name - Even name (e.g `click`)
   # target - Target element (e.g a link)
+  # name - Even name (e.g `click`)
   # callback - Wait for events to be processed, then call me (optional)
   fire: (selector, eventName, callback)->
     unless @window


### PR DESCRIPTION
Here's a small correction to some documentation and a comments. The comment describe the browser.fire function's parameters out of order. 

``` coffee
# zombie/lib/zombie/browser.coffee at line 399

# name - Even name (e.g `click`)
# target - Target element (e.g a link)
# callback - Wait for events to be processed, then call me (optional)
fire: (selector, eventName, callback)->
```

According to the use of all other events in browser.coffee the selector is the first parameter. 

``` coffee
# zombie/lib/zombie/browser.coffee at line 317

click: (selector)->
  @fire(selector, "click")
  return this 
```

The API also describes the event name as being the first parameter.

``` coffee
browser.fire(name, target, calback?)
```
