### PR TITLE
Prevent encoding errors when visiting a page in an encoding node doesn't recognize

### DIFF
--- a/lib/zombie/resources.coffee
+++ b/lib/zombie/resources.coffee
@@ -406,12 +406,15 @@ Resources.decodeBody = (request, response, next)->
   if response.body && response.headers
     contentType = response.headers["content-type"]
   if contentType
+    validTypes = ['hex', 'utf8', 'utf-8', 'ascii', 'binary', 'base64', 'ucs2', 'ucs-2', 'utf16le', 'utf-16le']
     [mimeType, typeOptions...] = contentType.split(/;\s+/)
     unless mimeType == "application/octet-stream"
       for typeOption in typeOptions
         if /^charset=/.test(typeOption)
-          charset = typeOption.split("=")[1]
-          break
+          for type in validTypes
+            if typeOption.split("=")[1] == type
+              charset = type
+              break
       response.body = response.body.toString(charset || "utf8")
   next()
   return


### PR DESCRIPTION
Zombie will throw an encoding error if a page's charset is set to an encoding that Node's `toString` method doesn't recognize (https://github.com/joyent/node/blob/master/lib/buffer.js#L438-L463), such as iso-8859-1. This change checks a page's charset against those encodings, and won't pass an encoding to `toString` if it's not one of node's valid encodings, letting it fall through to utf-8.

<!---
@huboard:{"order":363.0}
-->
