### PR TITLE
Browser.wait re-throws exceptions if callback is provided.

### DIFF
--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -289,7 +289,7 @@ class Browser extends EventEmitter
     promise = @eventLoop.wait(waitDuration, completionFunction)
 
     if callback
-      promise.then(callback, callback)
+      promise.then(callback, callback).done()
     return promise
 
 


### PR DESCRIPTION
Right now 2.0 is broken in respect of mocha and callbacks, because browser.wait callback is executed as a promise, so exceptions thrown in the callback by assertion frameworks are swallowed by Q.

```
browser.visit("http://www.google.com", function(done) {
  // ... assert something that fails
  done()
})
```

This will fail when the timeout fires with no useful error message. That's because assertion throws the useful exception, the exception is caught by Q that returns a rejected promise, the promise is discarded and done() is never executed.

I fixed it by forcing Q to end the chain and possibly rethrow the exception. Of course you cannot add more stuff to the returned promise anymore, but it makes sense that if you passed a callback you want the callback style, not the promise one. If that is the way I would consider not returning a promise at all to be more consistent. If that is not the way the callback style thing should be probably completely deprecated.

What do you think @assaf?
