### PR TITLE
Use status code in http module

### DIFF
--- a/lib/zombie/resources.coffee
+++ b/lib/zombie/resources.coffee
@@ -22,6 +22,7 @@ Path    = require("path")
 QS      = require("querystring")
 Request = require("request")
 URL     = require("url")
+HTTP    = require('http')
 Zlib    = require("zlib")
 assert  = require("assert")
 
@@ -83,7 +84,7 @@ class Resources extends Array
       else
         response.url        ||= request.url
         response.statusCode ||= 200
-        response.statusText = STATUS[response.statusCode] || "Unknown"
+        response.statusText = HTTP.STATUS_CODES[response.statusCode] || "Unknown"
         response.headers    ||= {}
         response.redirects  ||= 0
         response.time       = Date.now()
@@ -538,51 +539,5 @@ Resources.makeHTTPRequest = (request, callback)->
           redirects:    redirects
         callback(null, response)
   return
-
-
-
-# HTTP status code to status text
-STATUS =
-  100: "Continue"
-  101: "Switching Protocols"
-  200: "OK"
-  201: "Created"
-  202: "Accepted"
-  203: "Non-Authoritative"
-  204: "No Content"
-  205: "Reset Content"
-  206: "Partial Content"
-  300: "Multiple Choices"
-  301: "Moved Permanently"
-  302: "Found"
-  303: "See Other"
-  304: "Not Modified"
-  305: "Use Proxy"
-  307: "Temporary Redirect"
-  400: "Bad Request"
-  401: "Unauthorized"
-  402: "Payment Required"
-  403: "Forbidden"
-  404: "Not Found"
-  405: "Method Not Allowed"
-  406: "Not Acceptable"
-  407: "Proxy Authentication Required"
-  408: "Request Timeout"
-  409: "Conflict"
-  410: "Gone"
-  411: "Length Required"
-  412: "Precondition Failed"
-  413: "Request Entity Too Large"
-  414: "Request-URI Too Long"
-  415: "Unsupported Media Type"
-  416: "Requested Range Not Satisfiable"
-  417: "Expectation Failed"
-  500: "Internal Server Error"
-  501: "Not Implemented"
-  502: "Bad Gateway"
-  503: "Service Unavailable"
-  504: "Gateway Timeout"
-  505: "HTTP Version Not Supported"
-
 
 module.exports = Resources


### PR DESCRIPTION
I think that using [http status in Node.js](https://github.com/joyent/node/blob/master/lib/http.js#L197-L254) is more maintainable for `Zombie`. 

The diff for this change (using Node.js 0.8.16) is the followings:

``` diff
--- status_code_in_zombie.json2013-01-04 20:07:43.000000000 +0900
+++ status_code_in_http_module.json2013-01-04 20:07:09.000000000 +0900
@@ -1,16 +1,18 @@
 {
   "100": "Continue",
   "101": "Switching Protocols",
+ "102": "Processing",
   "200": "OK",
   "201": "Created",
   "202": "Accepted",
- "203": "Non-Authoritative",
+ "203": "Non-Authoritative Information",
   "204": "No Content",
   "205": "Reset Content",
   "206": "Partial Content",
+ "207": "Multi-Status",
   "300": "Multiple Choices",
   "301": "Moved Permanently",
- "302": "Found",
+ "302": "Moved Temporarily",
   "303": "See Other",
   "304": "Not Modified",
   "305": "Use Proxy",
@@ -23,20 +25,34 @@
   "405": "Method Not Allowed",
   "406": "Not Acceptable",
   "407": "Proxy Authentication Required",
- "408": "Request Timeout",
+ "408": "Request Time-out",
   "409": "Conflict",
   "410": "Gone",
   "411": "Length Required",
   "412": "Precondition Failed",
   "413": "Request Entity Too Large",
- "414": "Request-URI Too Long",
+ "414": "Request-URI Too Large",
   "415": "Unsupported Media Type",
   "416": "Requested Range Not Satisfiable",
   "417": "Expectation Failed",
+ "418": "I\'m a teapot",
+ "422": "Unprocessable Entity",
+ "423": "Locked",
+ "424": "Failed Dependency",
+ "425": "Unordered Collection",
+ "426": "Upgrade Required",
+ "428": "Precondition Required",
+ "429": "Too Many Requests",
+ "431": "Request Header Fields Too Large",
   "500": "Internal Server Error",
   "501": "Not Implemented",
   "502": "Bad Gateway",
   "503": "Service Unavailable",
- "504": "Gateway Timeout",
- "505": "HTTP Version Not Supported"
+ "504": "Gateway Time-out",
+ "505": "HTTP Version not supported",
+ "506": "Variant Also Negotiates",
+ "507": "Insufficient Storage",
+ "509": "Bandwidth Limit Exceeded",
+ "510": "Not Extended",
+ "511": "Network Authentication Required"
 }
```
