### PR TITLE
Make sure XMLHttpRequest#responseText is always a string

### DIFF
--- a/lib/zombie/xhr.coffee
+++ b/lib/zombie/xhr.coffee
@@ -132,7 +132,7 @@ class XMLHttpRequest
       @_responseHeaders = response.headers
       @_stateChanged(XMLHttpRequest.HEADERS_RECEIVED, listener)
 
-      @responseText = @_textBody(response.body)
+      @responseText = response.body?.toString() || ""
       @responseXML = null
       @_stateChanged(XMLHttpRequest.DONE, listener)
 
@@ -157,12 +157,6 @@ class XMLHttpRequest
           listener.call(this)
         catch error
           raise(element: @_window.document, from: __filename, scope: "XHR", error: error)
-
-  _textBody: (body)->
-    if body instanceof Buffer
-      body.toString()
-    else
-      body
       
 
 

--- a/test/xhr_test.coffee
+++ b/test/xhr_test.coffee
@@ -154,6 +154,31 @@ describe "XMLHttpRequest", ->
     it "should post with no data", ->
       browser.assert.text "title", "201posted"
 
+  describe "empty response", ->
+    before (done)->
+      brains.get "/xhr/get-empty", (req, res)->
+        res.send """
+        <html>
+          <head><script src="/jquery.js"></script></head>
+          <body>
+            <script>
+              $.get("/xhr/empty", function(response, status, xhr) {
+                document.text = xhr.responseText;
+              });
+            </script>
+          </body>
+        </html>
+        """
+      brains.get "/xhr/empty", (req, res)->
+        res.send ""
+      brains.ready done
+
+    before (done)->
+      browser.visit("http://localhost:3003/xhr/get-empty", done)
+
+    it "responseText should be an empty string", ->
+      assert.strictEqual "", browser.document.text
+
   describe "response text", ->
     before (done)->
       brains.get "/xhr/get-utf8-octet-stream", (req, res)->


### PR DESCRIPTION
The [XMLHttpRequest Level 2](http://www.w3.org/TR/XMLHttpRequest2/) specification requires the `responseText` attribute to be a "text response entity body". Accoding to [the relevant section](http://www.w3.org/TR/XMLHttpRequest2/#text-response-entity-body) in the spec, this means that it must always be a string, regardless of the response's content type.

The commit of this pull request adjusts zombie.js to match this behavior. Previously, `responseText` would be a `Buffer` in such cases.
