### PR TITLE
Test against correctly upper-cased method names

### DIFF
--- a/lib/zombie/xhr.coffee
+++ b/lib/zombie/xhr.coffee
@@ -69,7 +69,7 @@ class XMLHttpRequest
 
     # Check supported HTTP method
     method = method.toUpperCase()
-    if /^(connect|trace|track)$/.test(method)
+    if /^(CONNECT|TRACE|TRACK)$/.test(method)
       throw new HTML.DOMException(HTML.SECURITY_ERR, "Unsupported HTTP method")
     unless /^(DELETE|GET|HEAD|OPTIONS|POST|PUT)$/.test(method)
       throw new HTML.DOMException(HTML.SYNTAX_ERR, "Unsupported HTTP method")


### PR DESCRIPTION
We upper-case the method name immediately before testing, so the strings we are testing against should be upper-case as well.
