### PR TITLE
Test against node.js 0.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - 0.8
+  - "0.8"
+  - "0.10"
 notifications:
   email:
     on_success: always


### PR DESCRIPTION
This tells Travis CI to test Zombie against node.js 0.10.x.

As far as I can tell, it totally blows up.
