### PR TITLE
wait calls callback directly with promise result

### DIFF
--- a/lib/zombie/browser.coffee
+++ b/lib/zombie/browser.coffee
@@ -304,7 +304,7 @@ class Browser extends EventEmitter
     promise = @eventLoop.wait(waitDuration, completionFunction)
 
     if callback
-      Q.nodeify promise, callback
+      promise.then(callback, callback)
     return promise
 
 

--- a/test/event_loop_test.coffee
+++ b/test/event_loop_test.coffee
@@ -229,6 +229,22 @@ describe "EventLoop", ->
     it "should not wait longer than specified", ->
         browser.assert.text "title", "...."
 
+  describe "browser.wait failure", ->
+    before (done)->
+      browser.visit("http://localhost:3003/eventloop/function")
+        .then ->
+          browser.window.setInterval ->
+            @document.title += "."
+          , 100
+          return
+        .then(done, done)
+
+    it "should call callback with error", (done) ->
+      finished = (err)->
+        assert(err is 'oops')
+        done()
+
+      browser.wait (-> throw 'oops'), finished
 
   describe "page load", ->
     before ->


### PR DESCRIPTION
My callback for wait was getting called twice.  This resolves the issue.  Does it still handle errors the way you would like, or do we need something different?

The tests all pass, except for 'global leaks detected: a, n, b' on the selection link test.  That was failing before the change.

<!---
@huboard:{"order":366.0}
-->
