### PR TITLE
Fire an `input` event when filling in a text field.

### DIFF
--- a/src/zombie/browser.coffee
+++ b/src/zombie/browser.coffee
@@ -700,6 +700,7 @@ class Browser extends EventEmitter
     start_value = field.value
     field.value = value
     if start_value != value
+      @fire(field, "input")
       @fire(field, "change")
       @fire(field, "keydown")
       @fire(field, "keyup")

--- a/test/forms_test.coffee
+++ b/test/forms_test.coffee
@@ -154,7 +154,7 @@ describe "Forms", ->
   describe "fill field", ->
     before (done)->
       browser.visit "/forms/form", =>
-        fill_events = ["change", "keydown", "keyup", "keypress"]
+        fill_events = ["input", "change", "keydown", "keyup", "keypress"]
         count = fill_events.length
         browser.on "event", (event, target)=>
           if event.type in fill_events
@@ -169,7 +169,7 @@ describe "Forms", ->
     describe "fill input with same the same value", ->
       before ->
         browser.fill("Name", "")
-      it "should not fire change and key events", ->
+      it "should not fire input, change and key events", ->
         assert.equal @change, undefined
 
     describe "text input enclosed in label", ->
@@ -178,7 +178,7 @@ describe "Forms", ->
 
       it "should set text field", ->
         browser.assert.input "#field-name", "ArmBiter"
-      it "should fire change and key events", ->
+      it "should fire input, change and key events", ->
         assert.equal @changed.id, "field-name"
 
     describe "email input referenced from label", ->
@@ -187,7 +187,7 @@ describe "Forms", ->
 
       it "should set email field", ->
         browser.assert.input "#field-email", "armbiter@example.com"
-      it "should fire change and key events", ->
+      it "should fire input, change and key events", ->
         assert.equal @changed.id, "field-email"
 
     describe "textarea by field name", ->
@@ -196,7 +196,7 @@ describe "Forms", ->
 
       it "should set textarea", ->
         browser.assert.input "#field-likes", "Arm Biting"
-      it "should fire change and key events", ->
+      it "should fire input, change and key events", ->
         assert.equal @changed.id, "field-likes"
 
     describe "password input by selector", ->
@@ -205,7 +205,7 @@ describe "Forms", ->
 
       it "should set password", ->
         browser.assert.input "#field-password", "b100d"
-      it "should fire change and key events", ->
+      it "should fire input, change and key events", ->
         assert.equal @changed.id, "field-password"
 
     describe "input without a valid type", ->
@@ -214,7 +214,7 @@ describe "Forms", ->
 
       it "should set value", ->
         browser.assert.input "#field-invalidtype", "some value"
-      it "should fire change and key events", ->
+      it "should fire input, change and key events", ->
         assert.equal @changed.id, "field-invalidtype"
 
     describe "email2 input by node", ->
@@ -223,7 +223,7 @@ describe "Forms", ->
 
       it "should set email2 field", ->
         browser.assert.input "#field-email2", "headchomper@example.com"
-      it "should fire change and key events", ->
+      it "should fire input, change and key events", ->
         assert.equal @changed.id, "field-email2"
 
     describe "disabled input can not be modified", ->


### PR DESCRIPTION
See http://www.whatwg.org/specs/web-apps/current-work/multipage/common-input-element-attributes.html#event-input-input for details on the event. Basically, in a browser, it fires anytime the user performs an action that would cause the field's value.
