### PR TITLE
Set the accepts header when loading documents.

### DIFF
--- a/src/zombie/window.coffee
+++ b/src/zombie/window.coffee
@@ -347,6 +347,8 @@ loadDocument = ({ document, history, url, method, encoding, params })->
       unless headers.referer
         # HTTP header Referer, but Document property referrer
         headers.referer = document.referrer
+      unless headers.accept
+        headers.accept = 'text/html'
 
       window._eventQueue.http method, url, headers: headers, params: params, target: document, (error, response)->
         if error


### PR DESCRIPTION
I'm not sure if this is the best way to do this. Basically I've got an application that is using express and checks the request format. The problem I ran into was that zombie wasn't setting the `Accept` header in the request.

I'd like to hear if you think this is a good way to do this or not - I wasn't able to come up with anything else.

Thanks!
