### PR TITLE
Added support for content encoding.

### DIFF
--- a/src/zombie/resources.coffee
+++ b/src/zombie/resources.coffee
@@ -383,8 +383,9 @@ Resources.specialURLHandlers = (request, next)->
 # Handle deflate and gzip transfer encoding.
 Resources.decompressBody = (request, response, next)->
   if response.body && response.headers
+    transferEncoding = response.headers["transfer-encoding"]
     contentEncoding = response.headers["content-encoding"]
-  switch contentEncoding
+  switch transferEncoding || contentEncoding
     when "deflate"
       Zlib.inflate response.body, (error, buffer)->
         unless error

--- a/test/resources_test.coffee
+++ b/test/resources_test.coffee
@@ -97,6 +97,23 @@ describe "Resources", ->
   describe "deflate", ->
     before ->
       brains.get "/resources/deflate", (req, res)->
+        res.setHeader "Transfer-Encoding", "deflate"
+        image = File.readFileSync("#{__dirname}/data/zombie.jpg")
+        Zlib.deflate image, (error, buffer)->
+          res.send(buffer)
+
+    before (done)->
+      browser.resources.get "http://localhost:3003/resources/deflate", (error, @response)=>
+        done()
+
+    it "should uncompress deflated response with transfer-encoding", ->
+      image = File.readFileSync("#{__dirname}/data/zombie.jpg")
+      assert.deepEqual image, @response.body
+
+
+  describe "deflate content", ->
+    before ->
+      brains.get "/resources/deflate", (req, res)->
         res.setHeader "Content-Encoding", "deflate"
         image = File.readFileSync("#{__dirname}/data/zombie.jpg")
         Zlib.deflate image, (error, buffer)->
@@ -106,12 +123,29 @@ describe "Resources", ->
       browser.resources.get "http://localhost:3003/resources/deflate", (error, @response)=>
         done()
 
-    it "should uncompress deflated response", ->
+    it "should uncompress deflated response with content-encoding", ->
       image = File.readFileSync("#{__dirname}/data/zombie.jpg")
       assert.deepEqual image, @response.body
 
 
   describe "gzip", ->
+    before ->
+      brains.get "/resources/gzip", (req, res)->
+        res.setHeader "Transfer-Encoding", "gzip"
+        image = File.readFileSync("#{__dirname}/data/zombie.jpg")
+        Zlib.gzip image, (error, buffer)->
+          res.send(buffer)
+
+    before (done)->
+      browser.resources.get "http://localhost:3003/resources/gzip", (error, @response)=>
+        done()
+
+    it "should uncompress gzipped response with transfer-encoding", ->
+      image = File.readFileSync("#{__dirname}/data/zombie.jpg")
+      assert.deepEqual image, @response.body
+
+
+  describe "gzip content", ->
     before ->
       brains.get "/resources/gzip", (req, res)->
         res.setHeader "Content-Encoding", "gzip"
@@ -123,7 +157,7 @@ describe "Resources", ->
       browser.resources.get "http://localhost:3003/resources/gzip", (error, @response)=>
         done()
 
-    it "should uncompress gzipped response", ->
+    it "should uncompress gzipped response with content-encoding", ->
       image = File.readFileSync("#{__dirname}/data/zombie.jpg")
       assert.deepEqual image, @response.body
 


### PR DESCRIPTION
Added test for gzip/deflate resources with the "Content-Encoding" header.  Added check for content encoding header in addition to transfer encoding to support gzip/deflate resources.

I based my changes on real-world needs and the following Wikipedia articles.

[HTTP Compression](http://en.wikipedia.org/wiki/HTTP_compression)
[List of HTTP header fields](http://en.wikipedia.org/wiki/List_of_HTTP_header_fields)
