### PR TITLE
Fix: XHR security check false positive

### DIFF
--- a/src/zombie/xhr.coffee
+++ b/src/zombie/xhr.coffee
@@ -10,6 +10,14 @@ HTML.NETWORK_ERR = 19
 HTML.ABORT_ERR = 20
 
 
+normalizeUrlPort = (url) ->
+  if url.protocol == 'https:' && url.port == '443' ||
+     url.protocol == 'http:' && url.port == '80'
+
+    delete url.port;
+  return url
+
+
 class XMLHttpRequest
   constructor: (window)->
     @_window = window
@@ -76,6 +84,10 @@ class XMLHttpRequest
 
     # Normalize the URL and check security
     url = URL.parse(URL.resolve(@_window.location.href, url))
+    
+    # Don't consider port if they are standard for http and https
+    url = normalizeUrlPort(url)
+    
     unless /^https?:$/i.test(url.protocol)
       throw new HTML.DOMException(HTML.NOT_SUPPORTED_ERR, "Only HTTP/S protocol supported")
     url.hostname ||= @_window.location.hostname


### PR DESCRIPTION
The XHR security check triggers a false positive (a security error). If a url provides a port even if this port is the standard one for http or https.

So I added a normalization function that removes the port from the url object, when the port specified is the same as the protocol's default (443 for https and 80 for http).

This error wis triggered on my side when using zombie.js to visit a site that used socket.io

It's a small issue, albeit annoying.

This is a simple but good fix. 
