### PR TITLE
Don't set unparseable cookies

### DIFF
--- a/src/zombie/cookies.coffee
+++ b/src/zombie/cookies.coffee
@@ -77,6 +77,7 @@ module.exports = class Cookies extends Array
       httpHeader = httpHeader.join(",")
     for cookie in httpHeader.split(/,(?=[^;,]*=)|,$/)
       cookie = Cookie.parse(cookie)
+      continue unless cookie?
       cookie.domain ||= domain
       cookie.path   ||= Tough.defaultPath(path)
       # Delete cookie before setting it, so we only store one cookie (per

--- a/test/cookies_test.coffee
+++ b/test/cookies_test.coffee
@@ -145,6 +145,10 @@ describe "Cookies", ->
       res.cookie "_dup",      "one",      path: "/"
       res.send "<html></html>"
 
+    brains.get "/cookies/invalid", (req,res)->
+      res.setHeader "Set-Cookie", "invalid"
+      res.send "<html></html>"
+
     brains.get "/cookies/echo", (req,res)->
       cookies = ("#{k}=#{v}" for k,v of req.cookies).join("; ")
       res.send cookies
@@ -182,6 +186,13 @@ describe "Cookies", ->
       it "should access most specific cookie", ->
         browser.assert.cookie "_multiple", "specific"
 
+    describe "invalid cookie", ->
+      before (done)->
+        browser.visit("/cookies/invalid", done)
+
+      it "should not have the cookie", ->
+        console.log(browser.document.cookie)
+        browser.assert.cookie "invalid", null
 
     describe "host in domain", ->
       it "should have access to host cookies", ->


### PR DESCRIPTION
Hi,

node-cookie adheres strictly to RFC 6265 and does not parse invalid cookies by spec like "testcookie".
This in turn caused Zombie to crash.

It turned up because some external services (such as Ink File Picker) check for cookie support with these simple strings.

Also added a test.
