### PR TITLE
fixes browser.dump() by implementing History.dump and EventLoop.dump

### DIFF
--- a/src/zombie/eventloop.coffee
+++ b/src/zombie/eventloop.coffee
@@ -130,6 +130,8 @@ class EventLoop
 
     return promise
 
+  dump: ()->
+  	[]
 
   # -- Event queue management --
 

--- a/src/zombie/history.coffee
+++ b/src/zombie/history.coffee
@@ -285,6 +285,16 @@ class History
       return @current.pushState
 
 
+  dump: ()->
+    cur = this.first
+    i = 1
+    dump = while cur
+      line = if cur.next then '#'+i+': ' else i+'. '
+      line += URL.format(cur.url)
+      cur = cur.next
+      ++i
+      line
+    dump
 
 # Returns true if the hash portion of the URL changed between the history entry
 # (entry) and the new URL we want to inspect (url).

--- a/src/zombie/window.coffee
+++ b/src/zombie/window.coffee
@@ -269,6 +269,7 @@ module.exports = createWindow = ({ browser, params, encoding, history, method, n
     pushState:    history.pushState.bind(history)
     replaceState: history.replaceState.bind(history)
     _submit:      history.submit.bind(history)
+    dump:         history.dump.bind(history)
   Object.defineProperties windowHistory,
     length:
       get: -> return history.length


### PR DESCRIPTION
Note that the EventLoop.dump implementation is a stub.
