### PR TITLE
@416, the charset from the response may not have an decoder available wi...

### DIFF
--- a/src/zombie/resources.coffee
+++ b/src/zombie/resources.coffee
@@ -413,7 +413,7 @@ Resources.decodeBody = (request, response, next)->
         if /^charset=/.test(typeOption)
           charset = typeOption.split("=")[1]
           break
-      response.body = response.body.toString(charset || "utf8")
+      response.body = response.body.toString("utf8")
   next()
   return
 


### PR DESCRIPTION
Hey just letting you know at line 416 in resources.js under src/zombie where the response is converted into the charset given in the HTTP response, if the charset isn't one available in node.js buffers (http://bit.ly/N8xw2X) which are utf8, utf16le, ascii, hex, base64 and of course binary, it won't be able to convert and will throw and exception even though the returned data is text. 

For example, I'm working with a page that reports it's encoding as iso-8859-1 so node is reading the expression as toString('iso-8859-1') which is throwing an exception. I think either switching it to utf8 or ascii rather than reading the charset from the HTTP response would correct the issue. I'm not well versed in HTTP/DOM stuff, just a guy programming a scraper, lol, so I may be completely off.

Love the project,

Thanks!
