### PR TITLE
Ignore JavaScript validation and execution if runScripts flag is false 

### DIFF
--- a/src/zombie/browser.coffee
+++ b/src/zombie/browser.coffee
@@ -32,7 +32,7 @@ require("./dom_iframe")
 # Browser options you can set when creating new browser, or on browser instance.
 BROWSER_OPTIONS = ["debug", "features", "headers", "htmlParser", "waitDuration",
                    "proxy", "referer", "silent", "site", "userAgent",
-                   "maxRedirects", "language"]
+                   "maxRedirects", "language", "runScripts"]
 
 MOUSE_EVENT_NAMES = ["mousedown", "mousemove", "mouseup"]
 
@@ -1221,6 +1221,9 @@ Browser.default =
 
   # Default time to wait (visit, wait, etc).
   waitDuration: "5s"
+
+  # Indicates whether or not to validate and execute JavaScript, default true.
+  runScripts: true
 
 
 

--- a/src/zombie/window.coffee
+++ b/src/zombie/window.coffee
@@ -173,6 +173,10 @@ module.exports = createWindow = ({ browser, params, encoding, history, method, n
 
   # Evaulate in context of window. This can be called with a script (String) or a function.
   window._evaluate = (code, filename)->
+    # Surpress JavaScript validation and execution
+    if !browser.runScript
+      return
+
     try
       # The current window, postMessage and window.close need this
       [originalInScope, browser._windowInScope] = [browser._windowInScope, window]


### PR DESCRIPTION
I was unable to suppress the validation and execution of JavaScript embedded within an HTML file.  As it turns out the feature did not seem to be implemented (as documented in the website).  So, I took a swag at an implementation and was able to use the existing documented runScripts flag and evaluate it during the window evaluation function.

In the future a more granular runScripts could be provided.  I saw the need for executing/validating some JS but not others.  However in the meantime, this will suppress any JS from validating or executing from an HTML page zombie is evaluating.

Thanks,

Tony
