### PR TITLE
Change to `applyQuerySelector` from  `applyQuerySelectorPrototype`

### DIFF
--- a/src/zombie/document.coffee
+++ b/src/zombie/document.coffee
@@ -22,7 +22,7 @@ module.exports = createDocument = (browser, window, referer)->
   jsdomBrowser = JSDOM.browserAugmentation(HTML, parser: browser.htmlParser)
   # HTTP header Referer, but Document property referrer
   document = new jsdomBrowser.HTMLDocument(referrer: referer)
-  JSDOMSelectors.applyQuerySelector(document, HTML)
+  JSDOMSelectors.applyQuerySelectorPrototype(HTML)
 
   if browser.hasFeature("scripts", true)
     features.ProcessExternalResources.push("script")


### PR DESCRIPTION
According to the [change](https://github.com/tmpvar/jsdom/commit/79c808a6bb9a01413829ad0fd805ae6819f3f645) in jsdom's selectors API,
use `applyQuerySelectorPrototype` instead of `applyQuerySelector` in `JSDOMSelectors`.
