### PR TITLE
Fix xhr onreadystatechange firing multiple times with state 4.

### DIFF
--- a/src/zombie/xhr.coffee
+++ b/src/zombie/xhr.coffee
@@ -101,7 +101,7 @@ class XMLHttpRequest
       url:      URL.format(url)
       headers:  {}
     @_pending.push(request)
-    @readyState = XMLHttpRequest.OPENED
+    @_stateChanged(XMLHttpRequest.OPENED)
     return
 
   # Sends the request. If the request is asynchronous (which is the default),
@@ -118,24 +118,27 @@ class XMLHttpRequest
     request.body = data
     request.timeout = @timeout
     @_window._eventQueue.http request.method, request.url, request, (error, response)=>
-      listener = @onreadystatechange
       # abort sets request.error
       error ||= request.error
       if error
         error = new HTML.DOMException(HTML.NETWORK_ERR, error.message)
-        @_stateChanged(XMLHttpRequest.DONE, listener)
+        @_stateChanged(XMLHttpRequest.DONE)
         return
 
-      # Since the request was not aborted, we set all the fields here.
+      # Since the request was not aborted, we set all the fields here and change
+      # the state to HEADERS_RECIEVED.
       @status           = response.statusCode
       @statusText       = response.statusText
       @_responseHeaders = response.headers
-      @_stateChanged(XMLHttpRequest.HEADERS_RECEIVED, listener)
+      @_stateChanged(XMLHttpRequest.HEADERS_RECEIVED)
 
-      @responseText = response.body?.toString() || ""
-      @responseXML = null
-      @onload.call(@) if @onload
-      @_stateChanged(XMLHttpRequest.DONE, listener)
+      # Give the onreadystatechange a chance to fire from the previous state
+      # change, then set the response fields and change the state to DONE.
+      @_window._eventQueue.enqueue =>
+        @responseText = response.body?.toString() || ""
+        @responseXML = null
+        @onload.call(@) if @onload
+        @_stateChanged(XMLHttpRequest.DONE)
 
     return
 
@@ -149,16 +152,15 @@ class XMLHttpRequest
     return
 
   # Fire onreadystatechange event
-  _stateChanged: (newState, listener)->
+  _stateChanged: (newState)->
     @readyState = newState
-    if listener
+    if @onreadystatechange
       # Since we want to wait on these events, put them in the event loop.
       @_window._eventQueue.enqueue =>
         try
-          listener.call(this)
+          @onreadystatechange.call(this)
         catch error
           raise(element: @_window.document, from: __filename, scope: "XHR", error: error)
-
 
 
 # Lifecycle states


### PR DESCRIPTION
I noticed that XHRs were firing with state 4 multiple times.  This doesn't affect jQuery, but it does cause problems with [superagent](https://github.com/visionmedia/superagent) and anybody coding with XHRs manually.

The root of the issue was that _stateChanged gets called with the correct states, but the @onreadystatechange listener is queued to run later, and when it finally does run the state has been changed.

I cleaned up some of the listener logic, wrapped the final _stateChange in an `enqueue`, and added a test for this scenario.
