### PR TITLE
Load 'link' tags when loading css is enabled

### DIFF
--- a/src/zombie/document.coffee
+++ b/src/zombie/document.coffee
@@ -30,6 +30,7 @@ module.exports = createDocument = (browser, window, referer)->
 
   if browser.hasFeature("css", false)
     features.FetchExternalResources.push("css")
+    features.FetchExternalResources.push("link")
   if browser.hasFeature("iframe", true)
     features.FetchExternalResources.push("iframe")
   JSDOM.applyDocumentFeatures(document, features)


### PR DESCRIPTION
Previously link tags were not handled and the css of those tags would not be loaded. This change makes sure that when `features = 'script css'`, the css will actually be loaded.
