### PR TITLE
Add insertAdjacentHTML to JSDOM patches

### DIFF
--- a/src/zombie/jsdom_patches.coffee
+++ b/src/zombie/jsdom_patches.coffee
@@ -91,3 +91,27 @@ HTML5.TreeBuilder.prototype.createElement = (name, attributes, namespace)->
       for i in [0...attributes.length]
         this.copyAttributeToElement(el, attributes[i])
   return el
+
+# Implement insertAdjacentHTML
+HTML.HTMLElement.prototype.insertAdjacentHTML = (position, html)->
+  container  = this.ownerDocument.createElementNS("http://www.w3.org/1999/xhtml", "_")
+  parentNode = this.parentNode
+
+  container.innerHTML = html
+
+  switch position.toLowerCase()
+    when "beforebegin"
+      while (node = container.firstChild)
+        parentNode.insertBefore(node, this)
+    when "afterbegin"
+      first_child = this.firstChild;
+      while (node = container.lastChild)
+        first_child = this.insertBefore(node, first_child);
+    when "beforeend"
+      while (node = container.firstChild)
+        this.appendChild(node)
+    when "afterend"
+      next_sibling = this.nextSibling
+      while (node = container.lastChild)
+        next_sibling = parentNode.insertBefore(node, next_sibling)
+

--- a/test/document_test.coffee
+++ b/test/document_test.coffee
@@ -89,6 +89,42 @@ describe "Document", ->
       it "should change active element", ->
         browser.assert.hasFocus @textarea
 
+  describe "insertAdjacentHTML", ->
+    before ->
+      brains.get "/document/insertAdjacentHTML", (req, res)->
+        res.send "<html><body><div><p id='existing'></p></div></body></html>"
+
+    before (done)->
+      browser.visit("/document/insertAdjacentHTML", done)
+
+    describe "beforebegin", ->
+      before ->
+        @div = browser.query("div")
+        @div.insertAdjacentHTML("beforebegin", "<p id='beforebegin'></p>")
+
+      it "should insert content before target element", ->
+        assert.equal browser.body.firstChild.getAttribute("id"), "beforebegin"
+
+    describe "afterbegin", ->
+      before ->
+        @div.insertAdjacentHTML("afterbegin", "<p id='afterbegin'></p>")
+
+      it "should insert content as the first child within target element", ->
+        assert.equal @div.firstChild.getAttribute("id"), "afterbegin"
+
+    describe "beforeend", ->
+      before ->
+        @div.insertAdjacentHTML("beforeend", "<p id='beforeend'></p>")
+
+      it "should insert content as the last child within target element", ->
+        assert.equal @div.lastChild.getAttribute("id"), "beforeend"
+
+    describe "afterend", ->
+      before ->
+        @div.insertAdjacentHTML("afterend", "<p id='afterend'></p>")
+
+      it "should insert content after the target element", ->
+        assert.equal browser.body.lastChild.getAttribute("id"), "afterend"
 
   after ->
     browser.destroy()


### PR DESCRIPTION
JSDOM does not currently support insertAdjacentHTML.  Add support for `Element.insertAdjacentHTML` based on this polyfill:

https://gist.github.com/eligrey/1276030
