### PR TITLE
Add strictSSL option that is passed to Request.

### DIFF
--- a/src/zombie/browser.coffee
+++ b/src/zombie/browser.coffee
@@ -31,7 +31,7 @@ require("./dom_iframe")
 
 # Browser options you can set when creating new browser, or on browser instance.
 BROWSER_OPTIONS   = ["debug", "features", "headers", "htmlParser", "waitDuration",
-                   "proxy", "referer", "silent", "site", "userAgent",
+                   "proxy", "referer", "silent", "site", "strictSSL", "userAgent",
                    "maxRedirects", "language", "runScripts"]
 
 # Supported browser features.
@@ -1217,6 +1217,9 @@ Browser.default =
 
   # You can use visit with a path, and it will make a request relative to this host/URL.
   site: undefined
+
+  # Check SSL certificates against CA
+  strictSSL: true
 
   # User agent string sent to server.
   userAgent: "Mozilla/5.0 Chrome/10.0.613.0 Safari/534.15 Zombie.js/#{Browser.VERSION}"

--- a/src/zombie/resources.coffee
+++ b/src/zombie/resources.coffee
@@ -70,6 +70,7 @@ class Resources extends Array
       body:       options.body
       time:       Date.now()
       timeout:    options.timeout || 0
+      strictSSL:  @browser.strictSSL
 
     resource =
       request:    request
@@ -473,6 +474,7 @@ Resources.makeHTTPRequest = (request, callback)->
       jar:            false
       followRedirect: false
       encoding:       null
+      strictSSL:      request.strictSSL
       timeout:        request.timeout || 0
 
     Request httpRequest, (error, response)=>


### PR DESCRIPTION
This should close assaf/zombie#548. However, there is currently a bug in [request](https://github.com/mikeal/request) 2.27.0 with node 0.10 so `strictSSL` does not work. See mikeal/request#418. There's a work-around referenced in [this comment](https://github.com/mikeal/request/issues/418#issuecomment-25158401).
