### PR TITLE
Support file:// urls containing URI escaped characters. Fixes Issue #545

### DIFF
--- a/src/zombie/resources.coffee
+++ b/src/zombie/resources.coffee
@@ -443,7 +443,7 @@ Resources.makeHTTPRequest = (request, callback)->
     # file system rather than getting node's http (which handles file://
     # poorly) involved.
     if request.method == "GET"
-      filename = Path.normalize(pathname)
+      filename = Path.normalize(decodeURI(pathname))
       File.exists filename, (exists)=>
         if exists
           File.readFile filename, (error, buffer)=>

--- a/test/data/dir with spaces/file_scheme with spaces.html
+++ b/test/data/dir with spaces/file_scheme with spaces.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>JS should change me</title>
+    <script type="text/javascript" src="file_scheme%20with%20spaces.js"></script>
+  </head>
+  <body>
+    <p>This fixture is used to test scripts loaded via a file uri scheme.</p>
+  </body>
+</html>

--- a/test/data/dir with spaces/file_scheme with spaces.js
+++ b/test/data/dir with spaces/file_scheme with spaces.js
@@ -1,0 +1,1 @@
+document.title = "file://";

--- a/test/history_test.coffee
+++ b/test/history_test.coffee
@@ -191,7 +191,7 @@ describe "History", ->
         browser.assert.url "http://localhost:3003/history/boo/"
 
     describe "open from file system", ->
-      fileURL = "file://#{__dirname}/data/index.html"
+      fileURL = encodeURI("file://#{__dirname}/data/index.html")
 
       before (done)->
         browser.visit(fileURL, done)

--- a/test/script_test.coffee
+++ b/test/script_test.coffee
@@ -376,6 +376,12 @@ describe "Scripts", ->
     it "should run scripts with file url src", ->
       browser.assert.text "title", "file://"
 
+  describe "file:// uri with encoded spaces", ->
+    before (done)->
+      browser.visit("file://#{__dirname}/data/dir%20with%20spaces/file_scheme%20with%20spaces.html", done)
+
+    it "should run scripts with file url src containing encoded spaces", ->
+      browser.assert.text "title", "file://"
 
   describe "javascript: URL", ->
     describe "existing page", ->


### PR DESCRIPTION
This commit allows the visit() method it accept file:// url's containing spaces (optionally uri escaped as %20), and other uri escaped characters. It does not treat '+' as an escaped space.  That will require further work.
