### PR TITLE
added failing test on form.elements

### DIFF
--- a/test/forms_test.coffee
+++ b/test/forms_test.coffee
@@ -1172,5 +1172,26 @@ describe "Forms", ->
         assert.equal browser.query(tagName).id, ""
 
 
+  describe "form.elements", ->
+    form = null
+    before (done) ->
+      browser.visit "/forms/form", ->
+        form = browser.query("form")
+        done()
+
+    it "should be an array-like object", ->
+      assert.ok form.elements
+      assert.ok !isNaN form.elements.length
+
+    it "should allow accessing inputs by index", ->
+      assert.ok form.elements[0]
+
+    it "should allow accessing inputs by name", ->
+      assert.ok form.elements["email"]
+
+    it "should return array when asked for radio inputs", ->
+      assert.ok form.elements["scary"]
+      assert.equal form.elements["scary"].length, 2
+
   after ->
     browser.destroy()


### PR DESCRIPTION
Zombie.js does not support returning radio inputs in form.elements properly. If there are more radio inputs found, form.elements[name] should return array with all of them, however now it does not.

Test case that exposes this behaviour has been added.

Screenshot below shows how Chrome (v31) returns array of all radio inputs.

![screen shot 2013-11-19 at 11 34 59](https://f.cloud.github.com/assets/1100170/1571510/d34003d4-5106-11e3-8154-dde7bf924459.png)
