### PR TITLE
adds --save-dev to the 'npm install zombie' command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Next, assuming you're using the mighty [Homebrew](http://mxcl.github.com/homebre
     $ curl http://npmjs.org/install.sh | sudo sh
     $ npm --version
     1.0.106
-    $ npm install zombie
+    $ npm install zombie --save-dev
 
 On Ubuntu try these steps:
 
@@ -64,7 +64,7 @@ On Ubuntu try these steps:
     v0.10.21
     $ npm --version
     1.3.11
-    $ npm install zombie
+    $ npm install zombie --save-dev
 
 On Windows you'll need Cygwin to get access to GCC, Python, etc.  [Read
 this](https://github.com/joyent/node/wiki/Building-node.js-on-Cygwin-(Windows))


### PR DESCRIPTION
because if someone is downloading using zombie for their tests, they should probably include it in their development dependencies in node / package.json.
