### PR TITLE
FIXED strictSSL option should be included on all requests

### DIFF
--- a/src/zombie/resources.coffee
+++ b/src/zombie/resources.coffee
@@ -524,9 +524,10 @@ Resources.makeHTTPRequest = (request, callback)->
           url:        response.url
           headers:    redirectHeaders
           redirects:  redirects
+          strictSSL:  request.strictSSL
           time:       request.time
           timeout:    request.timeout
-        @emit("redirect", request, response)
+        @emit("redirect", response, redirectRequest)
         @resources.runPipeline(redirectRequest, callback)
 
       else

--- a/test/browser_events_test.js
+++ b/test/browser_events_test.js
@@ -65,8 +65,8 @@ describe("Browser events", function() {
       browser.on('request', function(request) {
         events.resource.push([request]);
       });
-      browser.on('redirect', function(request, response) {
-        events.resource.push([request, response]);
+      browser.on('redirect', function(response, newRequest) {
+        events.resource.push([response, newRequest]);
       });
       browser.on('response', function(request, response) {
         events.resource.push([request, response]);
@@ -81,10 +81,10 @@ describe("Browser events", function() {
     });
 
     it("should receive resource redirects", function() {
-      let [request, response] = events.resource[1];
-      assert.equal(request.url, 'http://example.com/browser-events/resource');
+      let [response, newRequest] = events.resource[1];
       assert.equal(response.statusCode, 302);
       assert.equal(response.url, 'http://example.com/browser-events/redirected');
+      assert.equal(newRequest.url, response.url);
     });
 
     it("should receive resource responses", function() {


### PR DESCRIPTION
Redirects to SSL enabled servers with self-signed certificates fail with "Error: DEPTH_ZERO_SELF_SIGNED_CERT". Seems this is because the 'strictSSL' option gets left off of the request options when performing a redirect request.
