### PR TITLE
fails back to lookup to fix issue #643

### DIFF
--- a/src/zombie/dns_mask.coffee
+++ b/src/zombie/dns_mask.coffee
@@ -95,7 +95,10 @@ class DNSMask
             callback(error, addresses && addresses[0], 4)
           else
             @resolve domain, "AAAA", (error, addresses)=>
-              callback(error, addresses && addresses[0], 6)
+              if addresses
+                callback(error, addresses && addresses[0], 6)
+              else
+                @_lookup domain, family, callback
       else
         throw new Error("Unknown family " + family)
 


### PR DESCRIPTION
Chained another branch to call original lookup function to avoid failure on lookup domain `localhost` to fix issue #643 
