### PR TITLE
Remove explicit use of ./node_modules/.bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build":        "coffee --bare --compile --output lib/zombie src/zombie/*.coffee",
     "prepublish":   "coffee --bare --compile --output lib/zombie src/zombie/*.coffee",
     "postpublish":  "rm -rf html man7 lib",
-    "test":         "./node_modules/.bin/mocha"
+    "test":         "mocha"
   },
   "engines": {
     "node":         ">= 0.8.0"


### PR DESCRIPTION
npm's "scripts" functionality automatically adds executables from required libraries to the path when invoked.

Hence, there is no need to use the explicit "./node_modules/.bin/mocha" as just "mocha" will do. As per https://www.npmjs.org/doc/misc/npm-scripts.html#path (and I also tried it, just to make super sure :-) )

Feel free to ignore this, I just noticed it on the way through :-)
