### PR TITLE
Add implementation of Node.contains that jsdom is missing

### DIFF
--- a/src/zombie/jsdom_patches.coffee
+++ b/src/zombie/jsdom_patches.coffee
@@ -108,3 +108,18 @@ HTML.HTMLElement.prototype.insertAdjacentHTML = (position, html)->
       next_sibling = this.nextSibling
       while (node = container.lastChild)
         next_sibling = parentNode.insertBefore(node, next_sibling)
+
+# Implement documentElement.contains
+# e.g., if(document.body.contains(el)) { ... }
+# See https://developer.mozilla.org/en-US/docs/DOM/Node.contains
+HTML.Node.prototype.contains = (otherNode) ->
+  # DDOPSON-2012-08-16 -- This implementation is stolen from Sizzle's
+  # implementation of 'contains' (around line 1402).
+  # We actually can't call Sizzle.contains directly:
+  # * Because we define Node.contains, Sizzle will configure it's own
+  #   "contains" method to call us. (it thinks we are a native browser
+  #   implementation of "contains")
+  # * Thus, if we called Sizzle.contains, it would form an infinite loop.
+  #   Instead we use Sizzle's fallback implementation of "contains" based on
+  #   "compareDocumentPosition".
+  return !!(this.compareDocumentPosition(otherNode) & 16)

--- a/test/node_test.coffee
+++ b/test/node_test.coffee
@@ -1,0 +1,49 @@
+{ assert, brains, Browser } = require("./helpers")
+File = require("fs")
+
+describe "Node", ->
+
+  browser = null
+  before (done)->
+    browser = Browser.create()
+    brains.ready(done)
+
+  describe ".contains", ->
+
+    before ->
+      brains.get "/node/contains.html", (req, res)-> res.send """
+        <html>
+          <body>
+            <div class="body-child"></div>
+            <div class="parent">
+              <div class="child"></div>
+            </div>
+          </body>
+        </html>
+      """
+
+    before (done)->
+      browser.visit("/node/contains.html", done)
+
+      
+    it "should be true for direct children", ->
+      bodyChild = browser.query '.body-child'
+      assert.strictEqual browser.document.body.contains(bodyChild), true
+  
+    it "should be true for grandchild children", ->
+      child = browser.query '.child'
+      assert.strictEqual browser.document.body.contains(child), true
+
+    it "should be false for siblings", ->
+      bodyChild = browser.query '.body-child'
+      parent = browser.query '.parent'
+      assert.strictEqual parent.contains(bodyChild), false
+
+    it "should be false for parent", ->
+      child = browser.query '.child'
+      parent = browser.query '.parent'
+      assert.strictEqual child.contains(parent), false
+
+    it "should be false for self", ->
+      child = browser.query '.child'
+      assert.strictEqual child.contains(child), false


### PR DESCRIPTION
Currently zombie does not provide an implementation of Node.contains which is commonly implemented in browsers and documented here:  https://developer.mozilla.org/en-US/docs/Web/API/Node.contains

Ember.js 1.5.1 assumes that Node.contains is provided and so the lack of Node.contains breaks testing Ember.js applications.

It looks like zombie used to provide a Node.contains implementation but somehow it was lost in the 2.0.0 branch.  The original pull request #399.  My commit is the same implementation plus some testcases so hopefully the API will not got dropped again.
