### PR TITLE
add raise method to xhr to catch errors in handlers

### DIFF
--- a/src/zombie/xhr.coffee
+++ b/src/zombie/xhr.coffee
@@ -189,6 +189,9 @@ class XMLHttpRequest extends Events.EventTarget
         catch error
           raise(element: @_window.document, from: __filename, scope: "XHR", error: error)
 
+  # Raise error coming from jsdom
+  raise: (level, message, errObject)->
+    raise(element: @_window.document, from: __filename, scope: "XHR", error: errObject.error)
 
 # Lifecycle states
 XMLHttpRequest.UNSENT = 0

--- a/test/xhr_test.js
+++ b/test/xhr_test.js
@@ -367,6 +367,36 @@ describe("XMLHttpRequest", function() {
 
   });
 
+  describe("error in response handler", function() {
+    before(function() {
+      brains.static('/xhr/handler-error', `
+        <html>
+          <head><script src='/jquery.js'></script></head>
+          <body>
+            <script>
+              $.get('/xhr/handler-error/backend', function(response) {
+                throw new Error("This is an error");
+              });
+            </script>
+          </body>
+        </html>`);
+      brains.static('/xhr/handler-error/backend', "Something");
+    });
+
+    it("should throw the error in the response handler", function(done) {
+      browser.visit('/xhr/handler-error').then(function() {
+        done(new Error("Expected to see error in ajax response handler"));
+      }).fail(function(error) {
+        assert.strictEqual(
+          error.message,
+          "This is an error",
+          "Expected to see error in ajax response handler"
+        );
+        done();
+      });
+    });
+  });
+
 
   after(function() {
     browser.destroy();


### PR DESCRIPTION
While writing integration tests with zombie, we've noticed that the existence of thrown errors in XMLHttpRequest response handlers cause zombie's dependency jsdom to call the method raise on the XMLHttpRequest object, which is, as of now, missing. 

Apparently, a commit from more than two years ago in the jsdom repo broke zombie's correct behaviour: https://github.com/tmpvar/jsdom/commit/95cefe9d374d99080fd0a15481fc25214eb51bc3#commitcomment-730325. 

Adding a simple 'raise' instance method in xhr.coffee permits the jsdom call to be correctly forwarded, and the error to bubble up to the test itself, where it can be used in assertions.
