### PR TITLE
Fix argument order for browser.fire in API.md

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -567,13 +567,13 @@ of the many methods that accept a callback.
 In addition the browser is also an `EventEmitter`.  You can register any number
 of event listeners to any of the emitted events.
 
-### browser.fire(name, target, callback?)
+### browser.fire(target, name, callback?)
 
 Fires a DOM event.  You can use this to simulate a DOM event, e.g. clicking a
 link or clicking the mouse.  These events will bubble up and can be cancelled.
 
-The first argument is the event name (e.g. `click`). The second argument is the
-target element of the event.
+The first argument is the target element of the event. The second argument is
+the event name (e.g. `click`).
 
 Just like `wait`, this method either takes a callback or returns a promise (and
 will wait for events to fire).


### PR DESCRIPTION
The API documentation has the arguments for browser.fire() in the wrong order. In 2.0.0-alpha31, browser.fire takes the event target first and the event name second.
