### PR TITLE
Remove unused callback argument

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -322,21 +322,21 @@ control to the callback function when done.
 If there are event handlers, they will all be run before transferring control to
 the callback function.  Zombie.js can even support jQuery live event handlers.
 
-### browser.attach(selector, filename, callback) : this
+### browser.attach(selector, filename) : this
 
 Attaches a file to the specified input field.  The second argument is the file
 name (you cannot attach streams).
 
 Returns this so you can chain multiple methods.
 
-### browser.check(field, callback) : this
+### browser.check(field) : this
  
 Checks a checkbox.  The argument can be the field name, label text or a CSS
 selector.
 
 Returns this so you can chain multiple methods.
 
-### browser.choose(field, callback) : this
+### browser.choose(field) : this
 
 Selects a radio box option.  The argument can be the field name, label text or a
 CSS selector.
@@ -350,7 +350,7 @@ selector, field name (its `name` attribute) or the text value of a label
 associated with that field (case sensitive, but ignores leading/trailing
 spaces).
 
-### browser.fill(field, value, callback) : this
+### browser.fill(field, value) : this
 
 Fill in a field: input field or text area.  The first argument can be the field
 name, label text or a CSS selector.  The second argument is the field value.
@@ -382,7 +382,7 @@ For example:
 
 Returns nothing.
 
-### browser.select(field, value, callback) : this
+### browser.select(field, value) : this
  
 Selects an option.  The first argument can be the field name, label text or a
 CSS selector.  The second value is the option to select, by value or label.
@@ -395,20 +395,20 @@ See also `selectOption`.
 
 Returns this so you can chain multiple methods.
 
-### browser.selectOption(option, callback) : this
+### browser.selectOption(option) : this
 
 Selects the option (an `OPTION` element).
 
 Returns this so you can chain multiple methods.
 
-### browser.uncheck(field, callback) : this
+### browser.uncheck(field) : this
 
 Unchecks a checkbox.  The argument can be the field name, label text or a CSS
 selector.
 
 Returns this so you can chain multiple methods.
 
-### browser.unselect(field, value, callback) : this
+### browser.unselect(field, value) : this
  
 Unselects an option.  The first argument can be the field name, label text or a
 CSS selector.  The second value is the option to unselect, by value or label.
@@ -417,7 +417,7 @@ You can use this (or `unselectOption`) when dealing with multiple selection.
 
 Returns this so you can chain multiple methods.
 
-### browser.unselectOption(option, callback) : this
+### browser.unselectOption(option) : this
 
 Unselects the option (an `OPTION` element).
 


### PR DESCRIPTION
Removed callbacks from some call signatures that do not actually use the argument in the current implementation
