### PR TITLE
Add click documentation

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -205,6 +205,12 @@ You can do that by calling `browser.wait`, passing a callback to methods like
 
 Navigate to the previous page in history.
 
+
+### browser.click(selector, callback)
+
+This method is similar to `clickLink` except that the selector may correspond to
+an arbitrary element.
+
 ### browser.clickLink(selector, callback)
  
 Clicks on a link.  The first argument is the link text or CSS selector.


### PR DESCRIPTION
Added the `click` function to the documentation. I only found out about it when I found it in the source. Unfortunately, this was after I had implemented my own using a manual `fire` call.
