### PR TITLE
Make sure that setTimeout and setInterval return handles > 0

### DIFF
--- a/src/zombie/eventloop.coffee
+++ b/src/zombie/eventloop.coffee
@@ -331,10 +331,13 @@ class EventQueue
       delete @timers[index]
     timer = new Timeout(this, fn, delay, remove)
     @timers[index] = timer
-    return index
+    # The HTML 5 spec says that all timerIds must be > 0, so add
+    # 1 to the timer handle to avoid the 0 index
+    return index+1
 
   # Window.clearTimeout
-  clearTimeout: (index)->
+  clearTimeout: (timerHandle)->
+    index = timerHandle - 1
     timer = @timers[index]
     timer.stop() if timer
     return
@@ -347,10 +350,13 @@ class EventQueue
       delete @timers[index]
     timer = new Interval(this, fn, interval, remove)
     @timers[index] = timer
-    return index
+    # The HTML 5 spec says that all timerIds must be > 0, so add
+    # 1 to the timer handle to avoid the 0 index
+    return index+1
 
   # Window.clearInterval
-  clearInterval: (index)->
+  clearInterval: (timerHandle)->
+    index = timerHandle - 1
     timer = @timers[index]
     timer.stop() if timer
     return

--- a/test/event_loop_test.js
+++ b/test/event_loop_test.js
@@ -44,6 +44,23 @@ describe("EventLoop", function() {
       });
     });
 
+    describe("timerHandle of first setTimeout", function() {
+      // Use a new browser to make sure no other setTimeout call has
+      // happened yet
+      let localBrowser = Browser.create();
+      let timerHandle;
+
+      before(function*() {
+        yield localBrowser.visit('/eventloop/timeout');
+        timerHandle = localBrowser.window.setTimeout(function() {
+          this.document.title += " Two";
+        }, 100);
+      });
+
+      it("should be greater than 0", function() {
+        assert.equal(timerHandle, 1);
+      });
+    });
 
     describe("from timeout", function() {
       before(function*() {
@@ -195,6 +212,25 @@ describe("EventLoop", function() {
             <body></body>
           </html>
         `);
+      });
+    });
+
+    describe("timerHandle of first setInterval", function() {
+      // Use a new browser to make sure no other setInterval call has
+      // happened yet
+      let localBrowser = Browser.create();
+      let timerHandle;
+
+      before(function*() {
+        yield localBrowser.visit('/eventloop/interval');
+        timerHandle = localBrowser.window.setInterval(function() {
+          this.document.title += " Two";
+        }, 100);
+      });
+
+      it("should be greater than 0", function() {
+        assert.equal(timerHandle, 1);
+        localBrowser.window.clearInterval(timerHandle);
       });
     });
 


### PR DESCRIPTION
The HTML 5 spec, http://www.w3.org/TR/2011/WD-html5-20110525/timers.html, requires that setTimeout and setInterval handles be > 0 and some Javascript libraries already make this assumption.  One prominent library that makes this assumption is jQuery's ajax timeout code, which causes zombie execution to be slower than expected.  
