### PR TITLE
Changed the order of arguments for browser.fire in the documentation

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -573,13 +573,13 @@ of the many methods that accept a callback.
 In addition the browser is also an `EventEmitter`.  You can register any number
 of event listeners to any of the emitted events.
 
-### browser.fire(name, target, callback?)
+### browser.fire(target, name, callback?)
 
 Fires a DOM event.  You can use this to simulate a DOM event, e.g. clicking a
 link or clicking the mouse.  These events will bubble up and can be cancelled.
 
-The first argument it the event name (e.g. `click`), the second argument is the
-target element of the event.
+The first argument is the target element of the event,  the second argument is the
+event name (e.g. `click`).
 
 Just like `wait`, this method either takes a callback or returns a promise (and
 will wait for events to fire).


### PR DESCRIPTION
The order in which the documentation shows the parameters for browser.fire is inconsistent with the code. The code expects the event 
