### PR TITLE
make mocha use traceur as a compiler.

### DIFF
--- a/test/helpers/first.js
+++ b/test/helpers/first.js
@@ -1,29 +1,13 @@
-const File    = require('fs');
-const Module  = require('module');
 const traceur = require('traceur');
 
 
 // All JS files, excluding node_modules, are transpiled using Traceur.
-const originalRequireJs = Module._extensions['.js'];
-Module._extensions['.js'] = function(module, filename) {
-  if (/\/(node_modules|test\/scripts)\//.test(filename)) {
-    return originalRequireJs(module, filename);
-  } else {
-    const source = File.readFileSync(filename, 'utf8');
-    const compiled = traceur.compile(source, {
-      blockBinding:           true,
-      generators:             true,
-      generatorComprehension: true,
-      asyncFunctions:         true,
-      validate:     true,
-      filename:     filename,
-      sourceMap:    true
-    });
-    if (compiled.errors.length)
-      throw new Error(compiled.errors.join('\n'));
-    // No idea when/why Traceur adds an empty export
-    const cleaned = compiled.js.replace(/module.exports = {};/g, '');
-    return module._compile(cleaned, filename);
-  }
-};
+traceur.require.makeDefault(function(filename) {
+  return !(/\/(node_modules|test\/scripts)\//.test(filename));
+}, {
+  // for traceur >= 0.0.51
+  experimental: true
+});
 
+// for traceur < 0.0.50, not work in the new version.
+traceur.options.experimental = true;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
---require test/helpers/first.js
---compilers coffee:coffee-script
+--compilers coffee:coffee-script,js:./test/helpers/first
 --reporter spec
 --timeout 2s
 --growl


### PR DESCRIPTION
just like coffee.

Traceur have module extensions handler itself. I just switch to it.
