### PR TITLE
Fixed the coffee compilation to work on Windows too

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   ],
   "main":           "lib/zombie",
   "scripts": {
-    "build":        "coffee --bare --compile --output lib/zombie src/zombie/*.coffee",
-    "prepublish":   "coffee --bare --compile --output lib/zombie src/zombie/*.coffee",
+    "build":        "coffee --bare --compile --output lib/zombie src/zombie/",
+    "prepublish":   "coffee --bare --compile --output lib/zombie src/zombie/",
     "postpublish":  "rm -rf html man7 lib",
     "test":         "mocha"
   },


### PR DESCRIPTION
Windows will not expand the glob in the path. So let's pass the folder name instead, to allow Windows users to contribute as well.
