### PR TITLE
Allow failure for node 0.11 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - 0.10
   - 0.11
+matrix:
+  allow_failures:
+    - node_js: 0.11
 notifications:
   email:
     on_success: always


### PR DESCRIPTION
The tests have never passed on 0.11 since it was added months ago, so it does not make sense to make the build fail all the time yet

the alternative is to actually make Zombie work on 0.11, but I'm not able to do it.
