### PR TITLE
Fixed the handling of radio groups with the same name in different forms

### DIFF
--- a/src/zombie/forms.coffee
+++ b/src/zombie/forms.coffee
@@ -158,17 +158,18 @@ HTML.HTMLInputElement.prototype.click = ->
         if @checked
           click()
         else
-          radios = @ownerDocument.querySelectorAll("input[type=radio][name='#{@getAttribute("name")}']", @form)
+          radios = @ownerDocument.querySelectorAll("input[type=radio][name='#{@getAttribute("name")}']")
           checked = null
           for radio in radios
-            if radio.checked
+            if radio.checked and radio.form == @form
               checked = radio
               radio.checked = false
           @checked = true
           if !click()
             @checked = false
             for radio in radios
-              radio.checked = (radio == checked)
+              if radio.form == @form
+                radio.checked = (radio == checked)
     else
       click()
   return

--- a/src/zombie/jsdom_patches.coffee
+++ b/src/zombie/jsdom_patches.coffee
@@ -29,6 +29,20 @@ for element in [HTML.HTMLInputElement, HTML.HTMLButtonElement, HTML.HTMLParamEle
   element.prototype.__defineGetter__ "value", ->
     return @getAttribute("value") || ""
 
+# Fix the retrieval of radio inputs for a radio group
+# This backports the JsDom fix done in https://github.com/tmpvar/jsdom/pull/870
+HTML.HTMLInputElement.prototype.__defineSetter__ "checked", (checked) ->
+  @_initDefaultChecked();
+  if checked
+    @setAttribute 'checked', 'checked'
+
+    if @type == 'radio'
+      for  element in @_ownerDocument.getElementsByName(@name)
+        if element != this && element.tagName == "INPUT" && element.type == "radio" && element.form == @form
+          element.checked = false
+  else
+    @removeAttribute 'checked'
+
 
 # Default behavior for clicking on links: navigate to new URL if specified.
 HTML.HTMLAnchorElement.prototype._eventDefaults =

--- a/test/forms_test.coffee
+++ b/test/forms_test.coffee
@@ -102,6 +102,7 @@ describe "Forms", ->
 
             <input type="checkbox" id="field-prevent-check">
             <input type="radio" id="field-prevent-radio">
+            <input type="radio" name="radio_reused_name" id="field-radio-first-form" />
           </form>
           <div id="formless_inputs">
             <label>Hunter <input type="text" name="hunter_name" id="hunter-name"></label>
@@ -121,6 +122,9 @@ describe "Forms", ->
             <label>Powerglove <input name="hunter_powerglove" type="radio" value="glove"></label>
             <label>No powerglove <input name="hunter_powerglove" type="radio" value="noglove" checked="checked"></label>
           </div>
+          <form>
+            <input type="radio" name="radio_reused_name" id="field-radio-second-form" checked="checked" />
+          </form>
         </body>
       </html>
       """
@@ -500,6 +504,13 @@ describe "Forms", ->
 
       it "should fire blur event on previous field", ->
         assert true
+
+    describe "same radio name used in different forms", ->
+      before ->
+        browser.choose("#field-radio-first-form")
+
+      it "should not uncheck radio in other forms", ->
+        browser.assert.element "#field-radio-second-form:checked"
 
 
   describe "select option", ->
@@ -944,7 +955,7 @@ describe "Forms", ->
         if req.files
           [text, image] = [req.files.text, req.files.image]
           if text || image
-            file = (text || image)[0] 
+            file = (text || image)[0]
             data = File.readFileSync(file.path)
             if image
               digest = Crypto.createHash("md5").update(data).digest("hex")


### PR DESCRIPTION
This backports the JSDom fix done in https://github.com/tmpvar/jsdom/pull/870 as zombie uses a much older version.
It also fixes another place suffering from the bug in Zombie itself
