### PR TITLE
Add failing tests for immediately-available pushState and replaceState results.

### DIFF
--- a/test/history_test.js
+++ b/test/history_test.js
@@ -163,6 +163,18 @@ describe('History', function() {
           assert.equal(lastEvent.state.is, 'end');
         });
       });
+
+      describe('synchronously', function() {
+        before(async function(done) {
+          await browser.visit('/');
+          done();
+        });
+
+        it('should make state changes available to the next line of code', function() {
+          browser.history.pushState({ is: 'start' }, null, '/start');
+          browser.assert.url('/start');
+        });
+      });
     });
 
     describe('replaceState', function() {
@@ -198,6 +210,18 @@ describe('History', function() {
         });
         it('should fire popstate event', function() {
           assert(window.popstate);
+        });
+      });
+
+      describe('synchronously', function() {
+        before(async function(done) {
+          await browser.visit('/');
+          done();
+        });
+
+        it('should make state changes available to the next line of code', function() {
+          browser.history.replaceState({ is: 'start' }, null, '/start');
+          browser.assert.url('/start');
         });
       });
     });
@@ -517,4 +541,3 @@ describe('History', function() {
     browser.destroy();
   });
 });
-


### PR DESCRIPTION
This is for issue #781.

Backbone routing methods typically need to know the current state of the URL after they've been triggered.  This happens before the next turn of the event loop.

If you write a simple function to run in a Chrome or FF, the behavior is simple.  As soon as you execute pushState or replaceState (and, presumably all of the other history methods), the results of that state change are available on the very next line of code.
