### PR TITLE
Make it possible to override behavior of offsetWidth/offsetHeight

### DIFF
--- a/src/zombie/jsdom_patches.coffee
+++ b/src/zombie/jsdom_patches.coffee
@@ -45,6 +45,7 @@ HTML.HTMLAnchorElement.prototype._eventDefaults =
       else
         return 100
   Object.defineProperty HTML.HTMLElement.prototype, offset,
+    configurable: true
     get: ->
       return 0
 


### PR DESCRIPTION
An HTML element's `offsetWidth` and `offsetHeight` are set with `Object.defineProperty` as getters that always return `0` ([source](https://github.com/assaf/zombie/commit/f206bc3e35f8e569b102497b41eea0392b6fbcc8#diff-0a71f9e0c26d82bb8f0120554760bfb8R78)). As a result, the jQuery `:visible` filter always returns false ([source](https://github.com/jquery/jquery/blob/10399ddcf8a239acc27bdec9231b996b178224d3/src/css/hiddenVisibleSelectors.js)).

This PR makes it so that the behavior can be overridden.
