### PR TITLE
Extend Window with DataView

### DIFF
--- a/src/zombie/window.coffee
+++ b/src/zombie/window.coffee
@@ -146,6 +146,9 @@ module.exports = ({ browser, params, encoding, history, method, name, opener, pa
     img.height = height
     return img
 
+  # DataView: get from globals
+  window.DataView = DataView
+
   window.XPathException   = XPath.XPathException
   window.XPathExpression  = XPath.XPathExpression
   window.XPathEvaluator   = XPath.XPathEvaluator

--- a/test/window_test.js
+++ b/test/window_test.js
@@ -188,6 +188,13 @@ describe('Window', function() {
     });
   });
 
+  describe('DataView', function () {
+    it('should create a DataView', function () {
+      const window = browser.open();
+      assert.equal(window.DataView, DataView);
+      browser.assert.evaluate('new DataView(new ArrayBuffer(8)).byteLength', '8');
+    });
+  });
 
   describe('onload', function() {
     before(async function() {


### PR DESCRIPTION
Adds [`DataView`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) to Zombie's window scope. `DataView` is used in [browserify](https://github.com/substack/node-browserify), for example. I grab the constructor from the global scope when the window is created.

Let me know if there's anything I need to add or change to meet requirements.
