### PR TITLE
FIXED CSS test regressions (closes #802)

### DIFF
--- a/src/zombie/assert.coffee
+++ b/src/zombie/assert.coffee
@@ -145,7 +145,7 @@ class Assert
     elements = @browser.queryAll(selector)
     assert elements.length > 0, "Expected selector '#{selector}' to return one or more elements"
     for element in elements
-      actual = element.style[style]
+      actual = element.style.getPropertyValue(style)
       assertMatch actual, expected,
         message || "Expected element '#{selector}' to have style #{style} value of #{expected}, found #{actual}"
 


### PR DESCRIPTION
`cssstyle-0.2.22` used by `jsdom` has changed behavior of `element.style`.
