### PR TITLE
Allow failed/delayed/mocked resource URLs to be specified with RegExps

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,9 +928,11 @@ conditions by asking Zombie to simulate a failure.  For example:
 browser.resources.fail('/form/post');
 ```
 
-Resource URLs can be absolute or relative.  Relative URLs will match any
-request with the same path, so only use relative URLs that are specific to a
-given request.
+Resource URLs can be absolute or relative strings or regular expressions.
+Relative URLs will match any request with the same path, so only use relative
+URLs that are specific to a given request.  If the resource URL is a regular
+expression, it will be tested against the requested URL and the handler used
+if there is a match.
 
 Another issue you'll encounter in real-life applications are network latencies.
 When running tests, Zombie will request resources in the order in which they

--- a/src/zombie/resources.coffee
+++ b/src/zombie/resources.coffee
@@ -388,7 +388,12 @@ Resources.createBody = (request, next)->
 # response.
 Resources.specialURLHandlers = (request, next)->
   for [url, handler] in @resources.urlMatchers
-    if URL.resolve(request.url, url) == request.url
+    if url instanceof RegExp
+      if url.test request.url
+        handler(request, next)
+        return
+      
+    else if URL.resolve(request.url, url) == request.url
       handler(request, next)
       return
   next()

--- a/test/resources_test.js
+++ b/test/resources_test.js
@@ -68,6 +68,25 @@ describe('Resources', function() {
     });
   });
 
+  describe("fail URL regex", function() {
+    before(function() {
+      browser.resources.fail(/\/resource\/resourceRegex/, "Fail!");
+    });
+
+    it("should fail the request", async function() {
+      try {
+        await browser.visit('/resource/resourceRegex');
+        assert(false, "Request did not fail");
+      } catch (error) {
+        assert.equal(error.message, "Fail!");
+      }
+    });
+
+    after(function() {
+      browser.resources.restore('/resources/resourceRegex');
+    });
+  });
+
 
   describe('delay URL with timeout', function() {
     before(function() {


### PR DESCRIPTION
While trying to use the mock/delay/fail APIs with socket.io 1.x clients I found it difficult, because the URLs that are generated change each time.  For example, /socket.io-1.x/?EIO=3&transport=polling&t=1417012813261-0

This pull request adds the ability to match mocks/delay/fail handlers with a RegExp instead of just fixed strings.
