### PR TITLE
Make failed XHR requests trigger the onreadystatechange callback

### DIFF
--- a/src/zombie/xhr.coffee
+++ b/src/zombie/xhr.coffee
@@ -139,6 +139,7 @@ class XMLHttpRequest extends Events.EventTarget
 
       if error
         @status = 0
+        @responseText = ""
         @_stateChanged(XMLHttpRequest.DONE)
         error = new HTML.DOMException(HTML.NETWORK_ERR, error.message)
         event = new Events.Event('xhr')

--- a/test/xhr_test.js
+++ b/test/xhr_test.js
@@ -255,9 +255,11 @@ describe('XMLHttpRequest', function() {
             <script>
               document.readyStatesReceived = { 1:[], 2:[], 3:[], 4:[] };
               document.onloadTime = null;
+              document.responseText = { 1:null, 4:null};
               var xhr = new XMLHttpRequest();
               xhr.onreadystatechange = function(){
                 document.readyStatesReceived[xhr.readyState].push(Date.now())
+                document.responseText[xhr.readyState] = xhr.responseText;
               };
               xhr.onload = function() {
                   document.onloadTime = Date.now()
@@ -279,6 +281,10 @@ describe('XMLHttpRequest', function() {
 
     it('should not trigger onload to be called', function() {
       assert.equal(browser.document.onloadTime, null);
+    });
+
+    it('responseText should be empty on error', function() {
+        assert.equal(browser.document.responseText[4], "");
     });
 
     it('should get exactly one readyState of type 1 and 4', function() {


### PR DESCRIPTION
According to http://www.w3.org/TR/XMLHttpRequest/#dom-xmlhttprequest-readystate the readyState of an XHR object should be set to DONE when "The data transfer has been completed or _something went wrong during the transfer_". Currently, zombie only sets the DONE state when the request is completed successfully (from a network perspective).

This change makes onreadystatechange be called with DONE when an error occurs.  If an error occurs, the HEADERS_RECEIVED state is skipped.  Additionally, the status attribute is set to 0 on error, which makes the specification here:  http://www.w3.org/TR/XMLHttpRequest/#the-status-attribute 
