### PR TITLE
Added ability to ignore high status codes (issue 859)...

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -53,6 +53,7 @@ You can use the following options:
   timers fire.  Defaults to 0.5 seconds.
 - `localAddress` -- The outgoing IP address to use for requests. The default is the default route. Will fail
   if an IP address is used which is not bound to a local interface.
+- `continueOnError` -- By default, making ajax requests to pages whose status is an error will stop everything.  Set this option to `true` to continue in spite of the status code.
 
 The proxy URL specifies the host and port of the proxy.  It also supports HTTP
 Basic authentication, for example:

--- a/src/zombie/browser.coffee
+++ b/src/zombie/browser.coffee
@@ -41,7 +41,7 @@ debug = Debug("zombie")
 # Browser options you can set when creating new browser, or on browser instance.
 BROWSER_OPTIONS   = ["features", "headers", "htmlParser", "waitDuration",
                      "proxy", "referer", "silent", "site", "strictSSL", "userAgent",
-                     "maxRedirects", "language", "runScripts", "localAddress"]
+                     "maxRedirects", "language", "runScripts", "localAddress", "continueOnError"]
 
 # Supported browser features.
 BROWSER_FEATURES  = ["scripts", "css", "img", "iframe"]

--- a/src/zombie/eventloop.coffee
+++ b/src/zombie/eventloop.coffee
@@ -309,10 +309,11 @@ class EventQueue
   # callback - Called with error, or null and response
   #
   # Options:
-  #   headers   - Name/value pairs of headers to send in request
-  #   params    - Parameters to pass in query string or document body
-  #   body      - Request document body
-  #   timeout   - Request timeout in milliseconds (0 or null for no timeout)
+  #   headers         - Name/value pairs of headers to send in request
+  #   params          - Parameters to pass in query string or document body
+  #   body            - Request document body
+  #   timeout         - Request timeout in milliseconds (0 or null for no timeout)
+  #   continueOnError - Whether to continue if there are errors making an http request (false by default).
   #
   # Calls callback with response error or null and response object.
   http: (method, url, options, callback)->
@@ -325,8 +326,11 @@ class EventQueue
       if @queue
 
         # Since this is used by resourceLoader that doesn't check the response,
-        # we're responsible to turn anything other than 2xx/3xx into an error
-        if response && response.statusCode >= 400
+        # we're responsible to turn anything other than 2xx/3xx into an error.
+        #
+        # This can cause problems when testing the client-side handling of AJAX calls that return an error,
+        # and can be optionally disabled by setting continueOnError to true.
+        if response && response.statusCode >= 400 && (!options || !options.continueOnError)
           error = new Error("Server returned status code #{response.statusCode} from #{url}")
 
         @enqueue =>

--- a/src/zombie/eventloop.coffee
+++ b/src/zombie/eventloop.coffee
@@ -330,7 +330,7 @@ class EventQueue
         #
         # This can cause problems when testing the client-side handling of AJAX calls that return an error,
         # and can be optionally disabled by setting continueOnError to true.
-        if response && response.statusCode >= 400 && (!options || !options.continueOnError)
+        if response && response.statusCode >= 400 && !@browser.continueOnError
           error = new Error("Server returned status code #{response.statusCode} from #{url}")
 
         @enqueue =>

--- a/test/event_loop_test.js
+++ b/test/event_loop_test.js
@@ -522,5 +522,25 @@ describe('EventLoop', function() {
   after(function() {
     browser.destroy();
   });
+
+  // In a normal browser instance, a visit to a page that cannot be found would result in an uncaught error.
+  //
+  // With the new configuration option, it's allowed.
+  //
+  // NOTE: The default handling of 404 errors is already tested in browser_object_test.
+  describe('continue on error when asked to', function() {
+    var permissiveBrowser = Browser.create({continueOnError: true});
+    before(function() {
+      brains.static('/browser-events/continue-on-error', '<html>not found, dude.</html>', { status: 404 });
+
+      return permissiveBrowser.visit('/browser-events/continue-on-error');
+    });
+
+    it('should have loaded without errors.', function() {
+      assert.equal(browser.error, undefined, 'There should be no browser errors');
+    });
+  });
+
+
 });
 


### PR DESCRIPTION
When making client AJAX requests that are intended to fail, the default behavior (stopping the world and throwing an error on anything with a status code higher than 400) prevents testing of client-side error handling code.  This pull request adds the ability to turn off this behavior if needed.

See [issue 859](https://github.com/assaf/zombie/issues/859) for details.