### PR TITLE
Pass cookies to EventSource request

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -422,7 +422,7 @@ function setupWindow(window, args) {
   // Constructor for EventSource, URL is relative to document's.
   window.EventSource = function(url) {
     url = DOM.resourceLoader.resolve(document, url);
-    const eventSource = new EventSource(url);
+    const eventSource = new EventSource(url, { headers: { Cookie: window.cookies } });
     eventQueue.addEventSource(eventSource);
     return eventSource;
   };


### PR DESCRIPTION
Currently EventSource request is [initialized](https://github.com/assaf/zombie/blob/master/src/zombie/window.coffee#L233) with no document cookies passed, which in most cases (lost session) disables fine reproduction of real website behavior.

According to [eventsource documentation](https://github.com/aslakhellesoy/eventsource-node#setting-http-request-headers) they can be easily passed.
