### PR TITLE
Do not try to resolve an image on src deletion

### DIFF
--- a/src/dom/jsdom_patches.js
+++ b/src/dom/jsdom_patches.js
@@ -46,6 +46,7 @@ DOM.HTMLAnchorElement.prototype._eventDefaults.click = function(event) {
 // jsdom seemed to only queue the 'load' event
 DOM.HTMLImageElement.prototype._attrModified = function(name, value, oldVal) {
   if (name === 'src') {
+    if (value == null) return;
     const src = DOM.resourceLoader.resolve(this._ownerDocument, value);
     if (this.src !== src)
       DOM.resourceLoader.load(this, value);


### PR DESCRIPTION
Currently zombie crashes, whenever we try to remove src attribute from image element (undefined value is passed into url.resolve which crashes with _url is not a string_ error).

This update fixes that
