### PR TITLE
Fix file path in test case.

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -3,6 +3,7 @@
 const assert        = require('assert');
 const { isRegExp }  = require('util');
 const URL           = require('url');
+const Utils         = require('jsdom/lib/jsdom/utils');
 
 
 // Used to assert that actual matches expected value, where expected may be a function or a string.
@@ -58,7 +59,7 @@ module.exports = class Assert {
   // query).
   url(expected, message) {
     if (typeof expected === 'string') {
-      const absolute = URL.resolve(this.browser.location.href, expected);
+      const absolute = Utils.resolveHref(this.browser.location.href, expected);
       assertMatch(this.browser.location.href, absolute, message);
     } else if (isRegExp(expected) || typeof expected === 'function')
       assertMatch(this.browser.location.href, expected, message);
@@ -182,7 +183,7 @@ module.exports = class Assert {
       const matchedRegexp = matchingText.filter(element => url.test(element.href));
       assert(matchedRegexp.length, message || `Expected at least one link matching the given text and URL`);
     } else {
-      const absolute    = URL.resolve(this.browser.location.href, url);
+      const absolute    = Utils.resolveHref(this.browser.location.href, url);
       const matchedURL  = matchingText.filter(element => element.href === absolute);
       assert(matchedURL.length, message || `Expected at least one link matching the given text and URL`);
     }

--- a/src/document.js
+++ b/src/document.js
@@ -9,6 +9,7 @@ const EventSource             = require('eventsource');
 const WebSocket               = require('ws');
 const XMLHttpRequest          = require('./xhr');
 const URL                     = require('url');
+const Utils                   = require('jsdom/lib/jsdom/utils');
 
 
 // File access, not implemented yet
@@ -51,7 +52,7 @@ class DOMURL {
   constructor(url, base) {
     assert(url != null, new DOM.DOMException('Failed to construct \'URL\': Invalid URL'));
     if (base)
-      url = URL.resolve(base, url);
+      url = Utils.resolveHref(base, url);
     const parsed = URL.parse(url || 'about:blank');
     const origin = parsed.protocol && parsed.hostname && `${parsed.protocol}//${parsed.hostname}`;
     Object.defineProperties(this, {
@@ -491,7 +492,7 @@ module.exports = function loadDocument(args) {
   let { url } = args;
   if (url && browser.site) {
     const site  = /^(https?:|file:)/i.test(browser.site) ? browser.site : `http://${browser.site}`;
-    url   = URL.resolve(site, URL.parse(URL.format(url)));
+    url   = Utils.resolveHref(site, URL.format(url));
   }
   url     = url || 'about:blank';
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const Storages          = require('./storage');
 const Tough             = require('tough-cookie');
 const { Cookie }        = Tough;
 const URL               = require('url');
+const Utils             = require('jsdom/lib/jsdom/utils');
 
 
 // Version number.  We get this from package.json.
@@ -536,7 +537,7 @@ class Browser extends EventEmitter {
       [options, callback] = [{}, options];
 
     const site = /^(https?:|file:)/i.test(this.site) ? this.site : `http://${this.site || 'localhost'}/`;
-    url = URL.resolve(site, URL.parse(URL.format(url)));
+    url = Utils.resolveHref(site, URL.format(url));
 
     if (this.window)
       this.tabs.close(this.window);

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -2,8 +2,9 @@
 // See http://www.w3.org/TR/XMLHttpRequest/#the-abort()-method
 
 
-const DOM = require('./dom');
-const URL = require('url');
+const DOM   = require('./dom');
+const URL   = require('url');
+const Utils = require('jsdom/lib/jsdom/utils');
 
 
 class XMLHttpRequest extends DOM.EventTarget {
@@ -59,7 +60,7 @@ class XMLHttpRequest extends DOM.EventTarget {
     const headers = {};
 
     // Normalize the URL and check security
-    url = URL.parse(URL.resolve(this._window.location.href, url));
+    url = URL.parse(Utils.resolveHref(this._window.location.href, url));
     // Don't consider port if they are standard for http and https
     if ((url.protocol === 'https:' && url.port === '443') ||
         (url.protocol === 'http:'  && url.port === '80'))

--- a/test/history_test.js
+++ b/test/history_test.js
@@ -313,7 +313,7 @@ describe('History', function() {
     });
 
     describe('open from file system', function() {
-      const FILE_URL = encodeURI(`file://${__dirname}/data/index.html`).toLowerCase();
+      const FILE_URL = encodeURI(`file://${__dirname}/data/index.html`);
 
       before(function() {
         return browser.visit(FILE_URL);

--- a/test/history_test.js
+++ b/test/history_test.js
@@ -337,6 +337,30 @@ describe('History', function() {
       });
     });
 
+    // Node has a bug that causes the root path element to be lowercased which
+    // causes problems when loading files from the file system.
+    // See https://github.com/joyent/node/pull/14146
+    describe('open from file system with capitalized root', function() {
+      const FILE_URL = 'file:///Users/foo/index.html';
+
+      before(function (done) {
+        browser.visit(FILE_URL, function () {
+          // Ignore errors -- the file isn't real...
+          done();
+        });
+      });
+
+      it('should change location URL', function() {
+        browser.assert.url(FILE_URL);
+      });
+      it('should set window location', function() {
+        assert.equal(browser.window.location.href, FILE_URL);
+      });
+      it('should set document location', function() {
+        assert.equal(browser.document.location.href, FILE_URL);
+      });
+    });
+
     describe('change pathname', function() {
       before(()=> browser.visit('/'));
       before(function(done) {

--- a/test/jsdom_patches_test.js
+++ b/test/jsdom_patches_test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const Utils  = require('jsdom/lib/jsdom/utils');
+
+
+describe('Utils', function() {
+  describe('resolving HREFs', function() {
+    const patterns = [
+      ['http://localhost', 'foo', 'http://localhost/foo'],
+      ['http://localhost/foo/bar', 'baz', 'http://localhost/foo/baz'],
+      ['http://localhost/foo/bar', '/bar', 'http://localhost/bar'],
+      ['http://localhost', 'file://foo/Users', 'file://foo/Users'],
+      ['http://localhost', 'file:///Users/foo', 'file:///Users/foo'],
+      ['file://foo/Users', 'file:bar', 'file://foo/bar']
+    ];
+
+    it('returns the correct URL', function() {
+      patterns.forEach(function(pattern) {
+        assert.equal(Utils.resolveHref(pattern[0], pattern[1]), pattern[2]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This test case was broken on Linux running from a path containing an upper case letter. I may be missing something, but I'm not sure why it would be desirable to convert the path to lower case on any platform.