### PR TITLE
clarifies that zombie doesn't run with Node 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Zombie.js
 ### Insanely fast, headless full-stack testing using Node.js
 
-**Zombie 4.x** is tested with [io.js](https://iojs.org/en/index.html), but may
-also work with Node 0.12.  Use Zombie 3.1.x if you need to use Node 0.10.
+**Zombie 4.x** is tested with [io.js](https://iojs.org/en/index.html).  
+It doesn't work with Node 0.12.  Use Zombie 3.1.x if you need to use Node 0.10.
 
 
 ## The Bite


### PR DESCRIPTION
Execution fails due to [startsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)