### PR TITLE
Refactor browser.assert.text to use browser.text

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -194,13 +194,7 @@ module.exports = class Assert {
   //
   // You can also call this with a regular expression, or a function.
   text(selector, expected, message) {
-    const elements = this.browser.queryAll(selector);
-    assert(elements.length, `Expected selector "${selector}" to return one or more elements`);
-    const actual = elements
-      .map(elem => elem.textContent)
-      .join('')
-      .trim()
-      .replace(/\s+/g, ' ');
+    const actual = this.browser.text(selector);
     assertMatch(actual, expected || '', message);
   }
 


### PR DESCRIPTION
We were planning to add a browser.text method because we needed it for some assertions we were writing, and then we discovered it already existed. So we decided to remove the duplicate code from
browser.assert.text instead. Tests still pass, but no coverage was added.

See also https://github.com/assaf/zombie/blob/035920d7c705f6a721917449f9d139380222d2b1/src/index.js#L453-L464

(Pairing with Mike Kenyon <@mkenyon>)