### PR TITLE
Fix assert.elements bug.

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -108,13 +108,13 @@ module.exports = class Assert {
     else if (Number.isInteger(count))
       this.elements(selector, { exactly: count }, message);
     else {
-      if (count.exactly)
+      if (Number.isInteger(count.exactly))
         assert.equal(elements.length, count.exactly,
                      message || `Expected ${count.exactly} elements matching "${selector}", found ${elements.length}`);
-      if (count.atLeast)
+      if (Number.isInteger(count.atLeast))
         assert(elements.length >= count.atLeast,
                message || `Expected at least ${count.atLeast} elements matching "${selector}", found only ${elements.length}`);
-      if (count.atMost)
+      if (Number.isInteger(count.atMost))
         assert(elements.length <= count.atMost,
                message || `Expected at most ${count.atMost} elements matching "${selector}", found ${elements.length}`);
     }

--- a/test/assert_test.js
+++ b/test/assert_test.js
@@ -1,5 +1,6 @@
 const brains  = require('./helpers/brains');
 const Browser = require('../src');
+const assert  = require('assert');
 
 
 describe('Browser assert', function() {
@@ -7,6 +8,35 @@ describe('Browser assert', function() {
 
   before(function() {
     return brains.ready();
+  });
+
+  describe('elements', function () {
+    before(function() {
+      brains.static('/assert/elements', `
+        <div id="elem">
+          <div class="item"></div>
+          <div class="item"></div>
+        </div>
+      `);
+    });
+
+    before(function () {
+      return browser.visit('/assert/elements');
+    });
+
+    it('should default test {exactly: 1} when no parameter given', function () {
+      browser.assert.elements('#elem');
+    });
+
+    it('should test {exactly: n} when integer given', function () {
+      browser.assert.elements('.item', 2);
+    });
+
+    it('should fail when 0 given and an element was found', function () {
+      assert.throws(function () {
+        browser.assert.elements('#elem', 0);
+      });
+    });
   });
 
 


### PR DESCRIPTION
`assert.elements` did nothing when the value passed was `0`, making a few other tests noop. (e.g. https://github.com/assaf/zombie/blob/master/test/forms_test.js#L427)

The issue was `if (count.exactly)` evaluating to false when `count.exactly` was 0. Same goes for `count.atLeast` and `count.atMost`.

I fixed the issue and added a few tests including the `count.exactly = 0` case.