### PR TITLE
Upgrade Babel to upgrade Regenerator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "postpublish": "gulp tag"
   },
   "dependencies": {
-    "babel-runtime": "5.1.13",
+    "babel-runtime": "^5.5.6",
     "bluebird": "^2.9",
     "debug": "^2.1",
     "eventsource": "^0.1.6",
@@ -58,7 +58,7 @@
     "ws": "^0.7.1"
   },
   "devDependencies": {
-    "babel": "5.1.13",
+    "babel": "^5.5.6",
     "babel-eslint": "^3.0.1",
     "body-parser": "^1.12.3",
     "cookie-parser": "^1.3.4",


### PR DESCRIPTION
To work around `_regeneratorRuntime.awrap is not a function` errors.

If this gets merged, #921 and #922 should be updated accordingly and their
builds will probably pass.
