### PR TITLE
FIXED #935: using properties instead of attributes whenever possible

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -720,8 +720,8 @@ class Browser extends EventEmitter {
   fill(selector, value) {
     const field = this.field(selector);
     assert(field && (field.tagName === 'TEXTAREA' || (field.tagName === 'INPUT')), `No INPUT matching '${selector}'`);
-    assert(!field.getAttribute('disabled'), 'This INPUT field is disabled');
-    assert(!field.getAttribute('readonly'), 'This INPUT field is readonly');
+    assert(!field.disabled, 'This INPUT field is disabled');
+    assert(!field.readonly, 'This INPUT field is readonly');
 
     // Switch focus to field, change value and emit the input event (HTML5)
     field.focus();
@@ -735,8 +735,8 @@ class Browser extends EventEmitter {
   _setCheckbox(selector, value) {
     const field = this.field(selector);
     assert(field && field.tagName === 'INPUT' && field.type === 'checkbox', `No checkbox INPUT matching '${selector}'`);
-    assert(!field.getAttribute('disabled'), 'This INPUT field is disabled');
-    assert(!field.getAttribute('readonly'), 'This INPUT field is readonly');
+    assert(!field.disabled, 'This INPUT field is disabled');
+    assert(!field.readonly, 'This INPUT field is readonly');
 
     if (field.checked ^ value)
       field.click();
@@ -783,8 +783,8 @@ class Browser extends EventEmitter {
   _findOption(selector, value) {
     const field = this.field(selector);
     assert(field && field.tagName === 'SELECT', `No SELECT matching '${selector}'`);
-    assert(!field.getAttribute('disabled'), 'This SELECT field is disabled');
-    assert(!field.getAttribute('readonly'), 'This SELECT field is readonly');
+    assert(!field.disabled, 'This SELECT field is disabled');
+    assert(!field.readonly, 'This SELECT field is readonly');
 
     const options = Array.from(field.options);
     for (let option of options) {
@@ -825,9 +825,9 @@ class Browser extends EventEmitter {
   // Returns this.
   selectOption(selector) {
     const option = this.query(selector);
-    if (option && !option.getAttribute('selected')) {
+    if (option && !option.selected) {
       const select = this.xpath('./ancestor::select', option).iterateNext();
-      option.setAttribute('selected', 'selected');
+      option.selected = true;
       select.focus();
       this.fire(select, 'change', false);
     }
@@ -857,10 +857,10 @@ class Browser extends EventEmitter {
   // Returns this.
   unselectOption(selector) {
     const option = this.query(selector);
-    if (option && option.getAttribute('selected')) {
+    if (option && option.selected) {
       const select = this.xpath('./ancestor::select', option).iterateNext();
       assert(select.multiple, 'Cannot unselect in single select');
-      option.removeAttribute('selected');
+      option.selected = false;
       select.focus();
       this.fire(select, 'change', false);
     }
@@ -936,7 +936,7 @@ class Browser extends EventEmitter {
   pressButton(selector, callback) {
     const button = this.button(selector);
     assert(button, `No BUTTON '${selector}'`);
-    assert(!button.getAttribute('disabled'), 'This button is disabled');
+    assert(!button.disabled, 'This button is disabled');
     button.focus();
     return this.fire(button, 'click', callback);
   }

--- a/test/forms_test.js
+++ b/test/forms_test.js
@@ -612,17 +612,17 @@ describe('Forms', function() {
 
     describe('enclosed in label using option label', function() {
       before(function() {
-        browser.select('Looks', 'Bloody');
+        browser.select('Looks', 'Clean');
       });
 
       it('should set value', function() {
-        browser.assert.input('#field-looks', 'blood');
+        browser.assert.input('#field-looks', 'clean');
       });
-      it('should select first option', function() {
+      it('should select second option', function() {
         const select      = browser.querySelector('#field-looks');
         const options     = Array.prototype.slice.call(select.options);
-        const isSelected  = options.map((option)=> !!option.getAttribute('selected'));
-        assert.deepEqual(isSelected, [true, false, false]);
+        const isSelected  = options.map((option)=> !!option.selected);
+        assert.deepEqual(isSelected, [false, true, false]);
       });
       it('should fire change event', function() {
         assert.equal(changed.id, 'field-looks');
@@ -640,7 +640,7 @@ describe('Forms', function() {
       it('should select second option', function() {
         const select      = browser.querySelector('#field-state');
         const options     = Array.prototype.slice.call(select.options);
-        const isSelected  = options.map((option)=> !!option.getAttribute('selected'));
+        const isSelected  = options.map((option)=> !!option.selected);
         assert.deepEqual(isSelected, [false, true, false]);
       });
       it('should fire change event', function() {
@@ -659,7 +659,7 @@ describe('Forms', function() {
       it('should select second option', function() {
         const select      = browser.querySelector('#field-months');
         const options     = Array.prototype.slice.call(select.options);
-        const isSelected  = options.map((option)=> !!option.getAttribute('selected'));
+        const isSelected  = options.map((option)=> !!option.selected);
         assert.deepEqual(isSelected, [false, true, false, false]);
       });
       it('should fire change event', function() {
@@ -678,7 +678,7 @@ describe('Forms', function() {
       it('should select second option', function() {
         const select      = browser.querySelector('#field-kills');
         const options     = Array.prototype.slice.call(select.options);
-        const isSelected  = options.map((option)=> !!option.getAttribute('selected'));
+        const isSelected  = options.map((option)=> !!option.selected);
         assert.deepEqual(isSelected, [false, false, true]);
       });
       it('should fire change event', function() {
@@ -695,7 +695,7 @@ describe('Forms', function() {
         const field2 = browser.querySelector('#field-kills');
         browser.fill(field1, 'something');
         field2.addEventListener('focus', ()=> done());
-        browser.select(field2, 'Five');
+        browser.select(field2, 'Seventeen');
       });
 
       it('should fire focus event on selected field', function() {
@@ -712,7 +712,7 @@ describe('Forms', function() {
         const field2 = browser.querySelector('#field-kills');
         browser.fill(field1, 'something');
         field1.addEventListener('blur', ()=> done());
-        browser.select(field2, 'Five');
+        browser.select(field2, 'Seventeen');
       });
 
       it('should fire blur event on previous field', function() {
@@ -742,7 +742,7 @@ describe('Forms', function() {
       it('should select first and second options', function() {
         const select      = browser.querySelector('#field-hobbies');
         const options     = Array.prototype.slice.call(select.options);
-        const isSelected  = options.map((option)=> !!option.getAttribute('selected'));
+        const isSelected  = options.map((option)=> !!option.selected);
         assert.deepEqual(isSelected, [true, false, true]);
       });
       it('should fire change event', function() {
@@ -767,7 +767,7 @@ describe('Forms', function() {
       it('should unselect items', function() {
         const select      = browser.querySelector('#field-hobbies');
         const options     = Array.prototype.slice.call(select.options);
-        const isSelected  = options.map((option)=> !!option.getAttribute('selected'));
+        const isSelected  = options.map((option)=> !!option.selected);
         assert.deepEqual(isSelected, [true, false, false]);
       });
     });


### PR DESCRIPTION
This pull request is for fixing the issue #935 (wrong usage of attributes instead of properties).