### PR TITLE
Window.get selection

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -265,6 +265,10 @@ function setupWindow(window, args) {
     return response;
   };
 
+  window.getSelection = function() {
+    return {};
+  };
+
 
   // -- Opening and closing --
 

--- a/test/window_test.js
+++ b/test/window_test.js
@@ -353,6 +353,48 @@ describe('Window', function() {
   });
 
 
+  describe('getSelection', function(){
+    before(function() {
+      brains.static('/windows/getSelection', `
+        <html>
+          <head>
+            <title>Whatever</title>
+          </head>
+          <body>
+            <h1>Hello World</h1>
+            <script>
+              function logSelection() {
+                  console.log(window.getSelection().toString());
+              }
+            </script>
+            <button id="a-button" onclick="logSelection()"/>Log Selection</button>
+          </body>
+        </html>
+      `);
+      return brains.ready();
+    });
+
+    before(function(){
+      return browser.visit('/windows/getSelection');
+    });
+
+    it('should not result in a browser error', function() {
+      browser.click('#a-button');
+      assert.equal(browser.errors.length, 0);
+    });
+
+    it('should not throw an error when evaluated directly', async function() {
+      try {
+        browser.evaluate('window.getSelection();');
+      }
+      catch (error) {
+        throw new Error(error);
+      }
+    });
+
+  });
+
+
   after(function() {
     browser.destroy();
   });


### PR DESCRIPTION
Adds a do-nothing implementation of window.getSelection().

Fixes https://github.com/assaf/zombie/issues/726

Although this will stop TypeError from being raised, this implementation just returns an empty object. If any downstream process expects a real [Selection](https://developer.mozilla.org/en-US/docs/Web/API/Selection) object, further work needs to be done (arguably in the [jsdom project](https://github.com/tmpvar/jsdom)).
