### PR TITLE
Fix empty document.referrer property. This fixes #908, and fixes #932.

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -332,7 +332,7 @@ class History {
         name:     name,
         url:      url,
         parent:   parent,
-        referrer: this.current && this.current.window.document.referrer
+        referrer: this.current.url || this.current.window.document.referrer
       };
       const document = loadDocument(args);
       this.addEntry(document.defaultView, url);
@@ -488,4 +488,3 @@ module.exports = function createHistory(browser, focus) {
   const history = new History(browser, focus);
   return history.open.bind(history);
 };
-

--- a/test/forms_test.js
+++ b/test/forms_test.js
@@ -313,7 +313,7 @@ describe('Forms', function() {
         const field1 = browser.querySelector('#field-email2');
         const field2 = browser.querySelector('#field-email3');
         browser.fill(field1, 'something');
-        field2.addEventListener('blur', ()=> done());
+        field1.addEventListener('blur', ()=> done());
         browser.fill(field2, 'else');
       });
 
@@ -563,9 +563,9 @@ describe('Forms', function() {
       before(function(done) {
         const field1 = browser.querySelector('#field-scary');
         const field2 = browser.querySelector('#field-notscary');
-        browser.choose(field1);
-        field2.addEventListener('focus', ()=> done());
         browser.choose(field2);
+        field1.addEventListener('focus', ()=> done());
+        browser.choose(field1);
       });
 
       it('should fire focus event on selected field', function() {

--- a/test/history_test.js
+++ b/test/history_test.js
@@ -182,13 +182,13 @@ describe('History', function() {
           await browser.visit('/');
           browser.history.pushState({ is: 'first' }, null, '/first');
           browser.history.pushState({ is: 'second' },   null, '/second');
-          browser.back();
           browser.window.addEventListener('popstate', function(event) {
             lastEvent = event;
-            done();
           });
+          browser.back();
           browser.history.forward();
           browser.wait().done();
+          done();
         });
 
         it('should fire popstate event', function() {

--- a/test/tabs_test.js
+++ b/test/tabs_test.js
@@ -93,6 +93,7 @@ describe('Tabs', function() {
 
   describe('selecting new tab (2)', function() {
     before(function(done) {
+      const browser = new Browser();
       browser.tabs.closeAll();
       browser.open({ name: 'first'} );
       browser.open({ name: 'second' });


### PR DESCRIPTION
Many of us who were following the tutorial from the book "Web Development with Node and Express" found an issue when trying to pass a test that relies on the **document.referrer** property. After digging for a while into the code I found out that it was not set correctly.
