### PR TITLE
Immediately change location.href on .replace

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -48,6 +48,7 @@ class Location {
 
   replace(url) {
     this._history.replace(url);
+    this._url = url;
   }
 
   reload() {


### PR DESCRIPTION
So, I have a problem testing my Angular application that makes an internal redirect on another #hash. Angular makes dirty checking on `location.href` and expects it to change sometime before the next $digest cycle (https://github.com/angular/angular.js/blob/d077966ff1ac18262f4615ff1a533db24d4432a7/src/ng/location.js#L950-L953) and it's happening in browser, but not in zombie.

I've tracked it down to https://github.com/assaf/zombie/blob/master/src/history.js#L50, but could not been able to find where it propagates the value back from history.

Proposed change fixes the problem, though I wonder whether this is the right place for the change and is there are some known reason not to update `_url` immediately.
