### PR TITLE
Fix some tests leaking

### DIFF
--- a/test/forms_test.js
+++ b/test/forms_test.js
@@ -306,6 +306,8 @@ describe('Forms', function() {
     });
 
     describe('focus field (2)', function() {
+      let cb;
+
       before(function() {
         return browser.visit('/forms/form');
       });
@@ -313,12 +315,17 @@ describe('Forms', function() {
         const field1 = browser.querySelector('#field-email2');
         const field2 = browser.querySelector('#field-email3');
         browser.fill(field1, 'something');
-        field2.addEventListener('blur', ()=> done());
+        field2.addEventListener('blur', cb = ()=> done());
         browser.fill(field2, 'else');
       });
 
       it('should fire blur event on previous field', function() {
         assert(true);
+      });
+
+      after(function () {
+        const field2 = browser.querySelector('#field-email3');
+        field2.removeEventListener('blur', cb);
       });
     });
 
@@ -560,16 +567,23 @@ describe('Forms', function() {
     });
 
     describe('any radio button (1) ', function() {
+      let cb;
+
       before(function(done) {
         const field1 = browser.querySelector('#field-scary');
         const field2 = browser.querySelector('#field-notscary');
         browser.choose(field1);
-        field2.addEventListener('focus', ()=> done());
+        field2.addEventListener('focus', cb = ()=> done());
         browser.choose(field2);
       });
 
       it('should fire focus event on selected field', function() {
         assert(true);
+      });
+
+      after(function () {
+        const field2 = browser.querySelector('#field-notscary');
+        field2.removeEventListener('focus', cb);
       });
     });
 

--- a/test/history_test.js
+++ b/test/history_test.js
@@ -177,18 +177,18 @@ describe('History', function() {
 
       describe('go forwards', function() {
         let lastEvent;
+        let cb;
 
         before(async function(done) {
           await browser.visit('/');
           browser.history.pushState({ is: 'first' }, null, '/first');
           browser.history.pushState({ is: 'second' },   null, '/second');
           browser.back();
-          browser.window.addEventListener('popstate', function(event) {
+          browser.window.addEventListener('popstate', cb = function(event) {
             lastEvent = event;
-            done();
           });
           browser.history.forward();
-          browser.wait().done();
+          browser.wait().done(done);
         });
 
         it('should fire popstate event', function() {
@@ -196,6 +196,10 @@ describe('History', function() {
         });
         it('should include state', function() {
           assert.equal(lastEvent.state.is, 'second');
+        });
+
+        after(function () {
+          browser.window.removeEventListener('popstate', cb);
         });
       });
 

--- a/test/tabs_test.js
+++ b/test/tabs_test.js
@@ -92,12 +92,14 @@ describe('Tabs', function() {
 
 
   describe('selecting new tab (2)', function() {
+    let cb;
+
     before(function(done) {
       browser.tabs.closeAll();
       browser.open({ name: 'first'} );
       browser.open({ name: 'second' });
       browser.tabs.current = 1;
-      browser.tabs[1].addEventListener('blur', function() {
+      browser.tabs[1].addEventListener('blur', cb = function() {
         done();
       });
       browser.tabs.current = 0;
@@ -106,6 +108,10 @@ describe('Tabs', function() {
 
     it('should fire onblur event', function() {
       assert(true);
+    });
+
+    after(function () {
+      browser.tabs[1].removeEventListener('blur', cb);
     });
   });
 


### PR DESCRIPTION
Due to how they were written, several tests share the same browser object and may emit events on listeners outside their own `describe` block. Ideally, you need to create new browser object for every test, but a quick attempt to do that resulted in a bunch of tests failing so it will probably take some time.

There's likely a few more tests that may get false positive the same way, though it would be very hard to catch them unless you stumble on the bug or decide to rewrite the tests.