### PR TITLE
Fix canvas

### DIFF
--- a/src/dom/canvas.js
+++ b/src/dom/canvas.js
@@ -13,7 +13,7 @@ const defineSetter    = require('jsdom/lib/jsdom/utils').defineSetter;
 // https://github.com/tmpvar/jsdom/commit/f8d890342145bf7ee3ec5f4b12cbef88e7ced9de
 
 DOM.Document.prototype._elementBuilders.canvas = function(doc, s) {
-  var element = new DOM.HTMLCanvasElement(doc, s);
+  let element = new DOM.HTMLCanvasElement(doc, s);
   element._init();
   return element;
 }
@@ -31,7 +31,13 @@ DOM.HTMLCanvasElement.prototype._init = function() {
 
 DOM.HTMLCanvasElement.prototype.getContext = function(contextId) {
   if (this._nodeCanvas) {
-    return this._nodeCanvas.getContext(contextId) || null;
+    let ctx = this._nodeCanvas.getContext(contextId) || null;
+    // Replace ctx.canvas
+    // DOM expects to find reference to element in ctx.canvas. By default
+    // node-canvas sets reference to Canvas object.
+    // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/canvas
+    if (ctx) ctx.canvas = this;
+    return ctx;
   }
 
   notImplemented("HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)",

--- a/src/dom/canvas.js
+++ b/src/dom/canvas.js
@@ -1,0 +1,70 @@
+const DOM             = require('./index');
+const notImplemented  = require('jsdom/lib/jsdom/browser/utils').NOT_IMPLEMENTED;
+const defineGetter    = require('jsdom/lib/jsdom/utils').defineGetter;
+const defineSetter    = require('jsdom/lib/jsdom/utils').defineSetter;
+
+// Work around jsdom <= 6.3.0 canvas bug
+//
+// When using jsdom with canvas support (with node-canvas), it's not possile to
+// query canvas by id. The issue was initially reported in jsdom here:
+// https://github.com/tmpvar/jsdom/issues/737
+//
+// The official fix landed into jsdom 6.3.0:
+// https://github.com/tmpvar/jsdom/commit/f8d890342145bf7ee3ec5f4b12cbef88e7ced9de
+
+DOM.Document.prototype._elementBuilders.canvas = function(doc, s) {
+  var element = new DOM.HTMLCanvasElement(doc, s);
+  element._init();
+  return element;
+}
+
+DOM.HTMLCanvasElement.prototype._init = function() {
+  let Canvas;
+  try {
+    Canvas = require("canvas");
+  } catch (e) {}
+
+  if (typeof Canvas === "function") { // in browserify, the require will succeed but return an empty object
+    this._nodeCanvas = new Canvas(this.width, this.height);
+  }
+}
+
+DOM.HTMLCanvasElement.prototype.getContext = function(contextId) {
+  if (this._nodeCanvas) {
+    return this._nodeCanvas.getContext(contextId) || null;
+  }
+
+  notImplemented("HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)",
+    this._ownerDocument._defaultView);
+}
+
+DOM.HTMLCanvasElement.prototype.toDataURL = function(type) {
+  if (this._nodeCanvas) {
+    return this._nodeCanvas.toDataURL(type);
+  }
+
+  notImplemented("HTMLCanvasElement.prototype.toDataURL (without installing the canvas npm package)",
+    this._ownerDocument._defaultView);
+}
+
+defineGetter(DOM.HTMLCanvasElement.prototype, 'width', function() {
+  const parsed = parseInt(this.getAttribute('width'));
+  return (parsed < 0 || Number.isNaN(parsed)) ? 300 : parsed;
+});
+
+defineSetter(DOM.HTMLCanvasElement.prototype, 'width', function(v) {
+  v = parseInt(v);
+  v = (Number.isNaN(v) || v < 0) ? 300 : v;
+  this.setAttribute('width', v);
+});
+
+defineGetter(DOM.HTMLCanvasElement.prototype, 'height', function() {
+  const parsed = parseInt(this.getAttribute('height'));
+  return (parsed < 0 || Number.isNaN(parsed)) ? 150 : parsed;
+});
+
+defineSetter(DOM.HTMLCanvasElement.prototype, 'height', function(v) {
+  v = parseInt(v);
+  v = (Number.isNaN(v) || v < 0) ? 150 : v;
+  this.setAttribute('height', v);
+});

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -10,4 +10,5 @@ require('./iframe');
 require('./forms');
 require('./jsdom_patches');
 require('./scripts');
+require('./canvas');
 

--- a/test/canvas_test.js
+++ b/test/canvas_test.js
@@ -1,0 +1,57 @@
+const assert  = require('assert');
+const brains  = require('./helpers/brains');
+const Browser = require('../src');
+
+describe('Canvas', function() {
+  const browser = new Browser();
+
+  before(function() {
+    brains.static('/canvas', `
+      <html>
+        <body>
+          <canvas id="myCanvas" width="1" height="2"></canvas>
+        </body>
+      </html>`);
+
+    return brains.ready();
+  });
+
+  before(async function() {
+    await browser.visit('/canvas');
+  });
+
+  it('should query by tag name', function() {
+    browser.assert.element('canvas');
+  });
+
+  it('should query by id', function() {
+    browser.assert.element('#myCanvas');
+  });
+
+  it('should have width and height attributes', function() {
+    browser.assert.attribute('canvas', 'width', 1);
+    browser.assert.attribute('canvas', 'height', 2);
+  });
+
+
+  it('should draw red rectangle (requires node-canvas)', function() {
+    try {
+      require.resolve('canvas');
+    } catch (e) {
+      this.skip();
+    }
+
+    browser.assert.evaluate(function() {
+      var c = browser.query('canvas');
+      var ctx = c.getContext('2d');
+      ctx.fillStyle = 'red';
+      ctx.fillRect(0,0,1,2);
+      return ctx.getImageData(0,0,1,1).data;
+    }, [255, 0, 0, 255]);
+  });
+
+  after(function() {
+    browser.destroy();
+  });
+
+});

--- a/test/canvas_test.js
+++ b/test/canvas_test.js
@@ -33,21 +33,30 @@ describe('Canvas', function() {
     browser.assert.attribute('canvas', 'height', 2);
   });
 
-
-  it('should draw red rectangle (requires node-canvas)', function() {
+  describe('node-canvas', function() {
     try {
       require.resolve('canvas');
     } catch (e) {
-      this.skip();
+      before(function() { this.skip(); });
     }
 
-    browser.assert.evaluate(function() {
-      var c = browser.query('canvas');
-      var ctx = c.getContext('2d');
-      ctx.fillStyle = 'red';
-      ctx.fillRect(0,0,1,2);
-      return ctx.getImageData(0,0,1,1).data;
-    }, [255, 0, 0, 255]);
+    it('should draw red rectangle', function() {
+      browser.assert.evaluate(function() {
+        let c = browser.query('canvas');
+        let ctx = c.getContext('2d');
+        ctx.fillStyle = 'red';
+        ctx.fillRect(0,0,1,2);
+        return ctx.getImageData(0,0,1,1).data;
+      }, [255, 0, 0, 255]);
+    });
+
+    it('should have reference to element in ctx.canvas', function() {
+      browser.assert.evaluate(function() {
+        let c = browser.query('canvas');
+        let ctx = c.getContext('2d');
+        return ctx.canvas === c;
+      });
+    });
   });
 
   after(function() {


### PR DESCRIPTION
When using jsdom with canvas support (with node-canvas), it's not possile to query canvas by id. The issue was initially reported in jsdom https://github.com/tmpvar/jsdom/issues/737.

The official fix landed into jsdom 6.3.0 in https://github.com/tmpvar/jsdom/commit/f8d890342145bf7ee3ec5f4b12cbef88e7ced9de.
