### PR TITLE
inline scripts with invalid type attribute get executed

### DIFF
--- a/test/script_test.js
+++ b/test/script_test.js
@@ -376,7 +376,7 @@ describe('Scripts', function() {
         browser.assert.text('title', /internal.external/);
       });
 
-      it('should trigger onload event afert loading script', function() {
+      it('should trigger onload event after loading script', function() {
         browser.assert.text('title', /external.onload/);
       });
 
@@ -413,6 +413,26 @@ describe('Scripts', function() {
     });
   });
 
+  describe('scripts invalid type', function() {
+    before(function() {
+      brains.static('/script/invalid-type', `
+        <html>
+          <head>
+            <title>Types</title>
+          </head>
+          <body>
+            <script type="true/text/javascript">
+              document.title = "Executed"
+            </script>
+        </html>
+      `);
+      return browser.visit('/script/invalid-type');
+    });
+
+    it('should not run scripts with invalid type', function() {
+      browser.assert.text('title', 'Types');
+    });
+  });
 
   describe('script attributes', function() {
     before(function() {


### PR DESCRIPTION
Hi Assaf,

I just found out, that inline-script tags that have an invalid attribute-type will still get executed. This behaviour differs from other major browsers. See this snippet:

``` html
<html>
<body>

<script type="true/text/javascript">

console.log('i am executed on zombie/jsdom.');

</script>
</html>
```

will not be executed in other browsers, but on zombie/jsdom. The main problem is, that jQuery uses this trick with prepending `true/`(couldn't believe it either ...) when parsing html, that should be appended to the dom to disable the script tags temporarly.
With the current behaviour inline-script-snippets added to the dom with jQuerys html()-function will be executed twice on zombie but once on browsers (chrome).

I created a test, but I wasn't sure if you want to fix this in your JSDOM-Patch scripts.js workarounds or upstream?

Hope the test helps to understand.

Thank you so much
Philipp

References:
https://github.com/jquery/jquery/blob/master/src/manipulation.js#L52
