### PR TITLE
removeHandler method in Pipeline

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -90,11 +90,9 @@ class Pipeline extends Array {
   // Remove a request or response handler.
   removeHandler(handler) {
     assert(handler.call, 'Handler must be a function');
-    for(var key in this){
-      if(this[key] === handler){
-        delete this[key];
-        break;
-      }
+    var index = this.indexOf(handler);
+    if (index > -1) {
+        delete this[index];
     }
   }
 
@@ -109,11 +107,9 @@ class Pipeline extends Array {
   // Remove a request or response handler.
   static removeHandler(handler) {
     assert(handler.call, 'Handler must be a function');
-    for(var key in this._default){
-      if(this[key] === handler){
-        delete this._default[key];
-        break;
-      }
+    var index = this._default.indexOf(handler);
+    if (index > -1) {
+        delete this._default[index];
     }
   }
 

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -87,12 +87,34 @@ class Pipeline extends Array {
     this.push(handler);
   }
 
+  // Remove a request or response handler.
+  removeHandler(handler) {
+    assert(handler.call, 'Handler must be a function');
+    for(var key in this){
+      if(this[key] === handler){
+        delete this[key];
+        break;
+      }
+    }
+  }
+
   // Add a request or response handler.  This handler will be used by any new
   // pipeline instance (browser).
   static addHandler(handler) {
     assert(handler.call, 'Handler must be a function');
     assert(handler.length === 2 || handler.length === 3, 'Handler function takes 2 (request handler) or 3 (response handler) arguments');
     this._default.push(handler);
+  }
+  
+  // Remove a request or response handler.
+  static removeHandler(handler) {
+    assert(handler.call, 'Handler must be a function');
+    for(var key in this._default){
+      if(this[key] === handler){
+        delete this._default[key];
+        break;
+      }
+    }
   }
 
 

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -92,7 +92,7 @@ class Pipeline extends Array {
     assert(handler.call, 'Handler must be a function');
     var index = this.indexOf(handler);
     if (index > -1) {
-        delete this[index];
+      this.splice(index,1);
     }
   }
 
@@ -109,7 +109,7 @@ class Pipeline extends Array {
     assert(handler.call, 'Handler must be a function');
     var index = this._default.indexOf(handler);
     if (index > -1) {
-        delete this._default[index];
+      this._default.splice(index,1);
     }
   }
 

--- a/test/resources_test.js
+++ b/test/resources_test.js
@@ -202,20 +202,25 @@ describe('Resources', function() {
       pipelineHandler = function(browser, request){
         return new Fetch.Response('empty', { status: 204 });
       }
+      const pipelineLength = browser.pipeline.length;
       browser.pipeline.addHandler(pipelineHandler);
+      assert.equal(browser.pipeline.length, pipelineLength+1, 'Pipeline\'s length should increase by 1 after adding a handler');
       return browser.visit('/resources/resource');
     });
     it('should remove the handler from the pipeline', function() {
       let pipelineHasHandler = false
-        , pipelineHasHandlerAfter = false;
+        , pipelineHasHandlerAfter = false
+        , pipelineLengthBefore = browser.pipeline.length;
+        
+      browser.assert.status(204);
+      
       for (let i=0; i<browser.pipeline.length; i++) {
         if (browser.pipeline[i] === pipelineHandler) {
             pipelineHasHandler = true;
             break;
         }
       }
-      browser.assert.status(204);
-      assert(pipelineHasHandler, 'Browser\'s pipeline should have a handler');
+      assert(pipelineHasHandler, 'Pipeline should have a handler');
       browser.pipeline.removeHandler(pipelineHandler);
       for (let i=0; i<browser.pipeline.length; i++) {
         if (browser.pipeline[i] === pipelineHandler) {
@@ -224,6 +229,7 @@ describe('Resources', function() {
         }
       }
       assert(!pipelineHasHandlerAfter, 'Pipeline should not have a handler after its removal');
+      assert.equal(browser.pipeline.length, pipelineLengthBefore-1, 'Pipeline\'s length should decrease by 1 after removing a handler');
     });
     
     it('should not use the handler after it has been removed', function(){

--- a/test/resources_test.js
+++ b/test/resources_test.js
@@ -195,6 +195,43 @@ describe('Resources', function() {
       browser.pipeline.pop();
     });
   });
+  
+  describe('removeHandler request', function() {
+    let pipelineHandler; 
+    before(function(){
+      pipelineHandler = function(browser, request){
+        return new Fetch.Response('empty', { status: 204 });
+      }
+      browser.pipeline.addHandler(pipelineHandler);
+      return browser.visit('/resources/resource');
+    });
+    it('should remove the handler from the pipeline', function() {
+      let pipelineHasHandler = false
+        , pipelineHasHandlerAfter = false;
+      for (let i=0; i<browser.pipeline.length; i++) {
+        if (browser.pipeline[i] === pipelineHandler) {
+            pipelineHasHandler = true;
+            break;
+        }
+      }
+      browser.assert.status(204);
+      assert(pipelineHasHandler, 'Browser\'s pipeline should have a handler');
+      browser.pipeline.removeHandler(pipelineHandler);
+      for (let i=0; i<browser.pipeline.length; i++) {
+        if (browser.pipeline[i] === pipelineHandler) {
+            pipelineHasHandlerAfter = true;
+            break;
+        }
+      }
+      assert(!pipelineHasHandlerAfter, 'Pipeline should not have a handler after its removal');
+    });
+    
+    it('should not use the handler after it has been removed', function(){
+      return browser.visit('/resources/resource').then(function(){
+        browser.assert.status(200);
+      })
+    })
+  });
 
   describe('addHandler redirect', function () {
     before(function() {


### PR DESCRIPTION
This method can be useful for situations when handlers need to be removed after a specific request or response has been observed, e.g.,
```javascript
var githubPromise, githubResponse;
before(function(){
	githubPromise = new Promise(function(resolve, reject, response){
		var requestPipelineHandler = function(browser, request){
			if(request.method === 'GET' && /github\.com/.test(request.url)){
				console.log('resolve github request promise');
				browser.pipeline.removeHandler(requestPipelineHandler);
				resolve();
				githubResponse = response;
			}
			return response;
		}
		browser.pipeline.addHandler(requestPipelineHandler);
	});
	return browser.visit('/assaf/zombie/');
});
it('Should request Github', function(){
	return githubPromise;
});
it('Should have response status of 200', function(){
	expect(githubResponse.code).to.equal(200);
});
```