### PR TITLE
Fix `this` value in callback in constuctor of Headers

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -26,7 +26,7 @@ class Headers {
       for (let [name, value] of init)
         this.append(name, value);
     else if (init instanceof Object)
-      _.each(init, function(value, name) {
+      _.each(init, (value, name)=> {
         this.append(name, value);
       });
   }


### PR DESCRIPTION
If you give an object to the constructor of `Headers`, <q>TypeError: Cannot read property 'append' of undefined</q> occurs.

This pull request fixes it.

## A code sample to reproduce the problem 

```js
// Based on the sample code in https://fetch.spec.whatwg.org/#headersinit
var Headers = require('zombie').Headers;
var meta = { "Content-Type": "text/xml", "Breaking-Bad": "<3" };
new Headers(meta);
```

### output

```
/home/vzvu3k6k/zombie/lib/fetch.js:72
      this.append(name, value);
          ^

TypeError: Cannot read property 'append' of undefined
    at /home/vzvu3k6k/zombie/lib/fetch.js:72:11
    at /home/vzvu3k6k/zombie/node_modules/lodash/index.js:3073:15
    at baseForOwn (/home/vzvu3k6k/zombie/node_modules/lodash/index.js:2046:14)
    at /home/vzvu3k6k/zombie/node_modules/lodash/index.js:3043:18
    at Function.<anonymous> (/home/vzvu3k6k/zombie/node_modules/lodash/index.js:3346:13)
    at new Headers (/home/vzvu3k6k/zombie/lib/fetch.js:71:42)
    at Object.<anonymous> (/home/vzvu3k6k/zombie/,/test.js:3:13)
    at Module._compile (module.js:399:26)
    at Object.Module._extensions..js (module.js:406:10)
    at Module.load (module.js:345:32)
    at Function.Module._load (module.js:302:12)
    at Function.Module.runMain (module.js:431:10)
    at startup (node.js:141:18)
    at node.js:977:3
```

Maybe I should write a test for it, but there seems to be no tests for `Headers` yet, so I skip it and just send a fix for now.