### PR TITLE
Add Referer header to xhr request

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -84,6 +84,7 @@ class XMLHttpRequest {
       throw new DOMException(DOMException.NOT_SUPPORTED_ERR, 'Only HTTP/S protocol supported');
     url.hostname = url.hostname || this._window.location.hostname;
     url.host = url.port ? `${url.hostname}:${url.port}` : url.hostname;
+    headers.set("Referer", this._window.location.href);
     if (url.host !== this._window.location.host) {
       headers.set('Origin', `${this._window.location.protocol}//${this._window.location.host}`);
       this._cors = headers.get('Origin');


### PR DESCRIPTION
Many modern browsers (like firefox, chrome) added this headers in xhr requests. 
Without this headers some sites, worked incorrect with xhr withour Referer header.