### PR TITLE
Relax node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - iojs
+  - 4.2.3
+  - 5.3.0
 env:
   - DEBUG=zombie
 notifications:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "José Valim <jose.valim@plataformatec.com.br> (http://blog.plataformatec.com.br/)"
   ],
   "engines": {
-    "node": "^4.0.0"
+    "node": ">=4.0.0"
   },
   "keywords": [
     "test",


### PR DESCRIPTION
This change is needed in order to install zombie on node 5.x with
strict engine:

`npm config set engine-strict true`

All tests are passing on node 5.3.0, so I see no reason to require 4.x only.