### PR TITLE
Treat curly rule violation as warning, not error.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
   // http://eslint.org/docs/rules/
   rules: {
     strict:               0,
-    curly:                [2, 'multi'],
+    curly:                [1, 'multi'],
     quotes:               [2, 'single'],
     eol-last:             [0],
     no-mixed-requires:    [0],


### PR DESCRIPTION
There are a few tests that use `for` loops with a single statement,
and this rule wants curly braces to be removed from such for loops.

I'm not sure what the code standard for this project is, so I went
for the simplest way to make the build pass. (On node 5.3.0).