### PR TITLE
fix adding custom headers with the browser's fetch

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -25,7 +25,7 @@ class Headers {
     if (init instanceof Headers || init instanceof Array)
       for (let [name, value] of init)
         this.append(name, value);
-    else if (init instanceof Object)
+    else if (typeof init === "object")
       _.each(init, (value, name)=> {
         this.append(name, value);
       });


### PR DESCRIPTION
Because of the behavior of nodejs regarding code run in vm.runInContext
method, object passed to zombie are not instance of the same Object
class. (see
https://github.com/nodejs/node/issues/4676#issuecomment-171430653)
So checking `init instanceof Object` returns `false` and no headers are
set.

This fixes https://github.com/assaf/zombie/issues/1004 

I am not sure how to test that, as I need to simulate a browser context. If you have any suggestion regarding testing, let me know