### PR TITLE
Fix potential memory leak when deleting all cookies

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -81,7 +81,7 @@ module.exports = class Cookies extends Array {
 
   // Deletes all cookies.
   deleteAll() {
-    this.length = 0;
+    this.splice(0, this.length);
   }
 
   // Update cookies with HTTP response


### PR DESCRIPTION
Using `browser.deleteCookies()` after each visit didn't seem to clear the cookies from memory. In my case, they were never garbage collected. I looked into it and found out setting the length of an array to 0 doesn't clear the memory (it creates a new one); using `splice` instead does.
