### PR TITLE
Reorder events in selectOption - causes a bad interaction with React linked values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -827,8 +827,8 @@ class Browser extends EventEmitter {
     const option = this.query(selector);
     if (option && !option.selected) {
       const select = this.xpath('./ancestor::select', option).iterateNext();
-      option.selected = true;
       select.focus();
+      option.selected = true;
       this.fire(select, 'change', false);
     }
     return this;
@@ -1355,4 +1355,3 @@ class Browser extends EventEmitter {
 
 
 module.exports = Browser;
-

--- a/test/forms_test.js
+++ b/test/forms_test.js
@@ -96,6 +96,11 @@ describe('Forms', function() {
               <option value="mar_2011"> Mar 2011 </option>
             </select>
 
+            <select name="onfocus-selector" id="onfocus-selector">
+              <option value="value1" selected>value1</option>
+              <option value="value2">value2</option>
+            </select>
+
             <input type="unknown" name="unknown" value="yes">
             <input type="reset" value="Reset">
             <input type="submit" name="button" value="Submit">
@@ -725,6 +730,29 @@ describe('Forms', function() {
 
       it('should fire blur event on previous field', function() {
         assert(true);
+      });
+    });
+
+    describe('with onfocus handler', function() {
+      before(function() {
+        return browser.visit('/forms/form');
+      });
+
+      it('should fire the onchange event with the new value', function(done) {
+        const selectField = browser.querySelector('#onfocus-selector');
+        selectField.addEventListener('focus', (e) => {
+          e.target.value = 'value1';
+        });
+        const changeListener = (e) => {
+          selectField.removeEventListener('change', changeListener);
+          if (e.target.value === 'value2') {
+            done();
+          } else {
+            done(new Error('Expected e.target.value to be "value2", was "' + e.target.value + '"'));
+          };
+        };
+        selectField.addEventListener('change', changeListener);
+        browser.select('#onfocus-selector', 'value2');
       });
     });
   });


### PR DESCRIPTION
The ordering of events in `selectOption` seems to cause problems when using React linked values, that do not show up when using other browsers.

The previous order was:
1. Set option as selected
2. Fire `focus` event
3. Fire `change` event

This causes problems when using React linked values. React updates its model from the DOM when it receives the `change` event, but updates the DOM from its model when it received the `focus` event. This means that the order of events is as follows:
1. The option is selected.
2. The `focus` event fires.
3. React observes the `focus` event, and changes the selected option to match its model, restoring the old value.
4. The `change` event fires. However the old value is now selected.
5. React observes the `change` event, but the old value is selected.

By moving the `focus` event before the change to the DOM, there is no longer a window for the change to be prevented by `focus` listeners.