### PR TITLE
Support xhr PATCH requests

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -68,7 +68,7 @@ class XMLHttpRequest {
     this._method = method.toUpperCase();
     if (/^(CONNECT|TRACE|TRACK)$/.test(this._method))
       throw new DOMException(DOMException.SECURITY_ERR, 'Unsupported HTTP method');
-    if (!/^(DELETE|GET|HEAD|OPTIONS|POST|PUT)$/.test(this._method))
+    if (!/^(DELETE|GET|HEAD|OPTIONS|POST|PUT|PATCH)$/.test(this._method))
       throw new DOMException(DOMException.SYNTAX_ERR, 'Unsupported HTTP method');
 
     const headers = new Fetch.Headers();
@@ -274,4 +274,3 @@ XMLHttpRequest.LOADING          = 3;
 XMLHttpRequest.DONE             = 4;
 
 module.exports = XMLHttpRequest;
-


### PR DESCRIPTION
Fix so ajax PATCH requests can be made (with JQuery, for example) instead of failing with a syntax error.