### PR TITLE
Fetch HeadersInit as an Array fixed and tests

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -22,7 +22,7 @@ class Headers {
 
   constructor(init) {
     this._headers = [];
-    if (init instanceof Headers || init instanceof Array)
+    if (init instanceof Headers || Array.isArray(init))
       for (let [name, value] of init)
         this.append(name, value);
     else if (typeof init === "object")

--- a/test/window_test.js
+++ b/test/window_test.js
@@ -187,6 +187,58 @@ describe('Window', function() {
     });
   });
 
+
+  describe('.fetch', function() {
+    before(function() {
+      brains.get('/window/fetch/data', (req, res) => {
+        assert.equal(req.get('X-Test'), 'ok');
+        res.send();
+      });
+    });
+
+    it('should process HeadersInit as an array from different context', async function() {
+      brains.static('/window/fetch/array-test', `
+        <html>
+          <script>
+            fetch('data', {
+              headers: [
+                ['X-Test', 'ok']
+              ]
+            }).then(function() {
+              document.dispatchEvent(new Event('fetched'));
+            });
+          </script>
+        </html>
+      `);
+
+      await browser.visit('/window/fetch/array-test');
+      await new Promise(resolve => {
+        browser.document.addEventListener('fetched', resolve);
+      });
+    });
+
+    it('should process HeadersInit as an object from different context', async function() {
+      brains.static('/window/fetch/object-test', `
+        <html>
+          <script>
+            fetch('data', {
+              headers: {
+                'X-Test': 'ok'
+              }
+            }).then(function() {
+              document.dispatchEvent(new Event('fetched'));
+            });
+          </script>
+        </html>
+      `);
+
+      await browser.visit('/window/fetch/object-test');
+      await new Promise(resolve => {
+        browser.document.addEventListener('fetched', resolve);
+      });
+    });
+  });
+
   describe('atob', function() {
     it('should decode base-64 string', function() {
       browser.open();


### PR DESCRIPTION
PR #1006 fixes an issue where HeadersInit is passed as an
Object from different context. This fixes array checking. Arrays passed
from a different context did not pass previous check and were recognized
as Object which caused unexpected results.

Test specs covering both Object and Array passed as HeadersInit has been
created.

This also covers and fixes #1004.
