### PR TITLE
Support ws 'buffer' binaryType for socket.io compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ms": "^0.7.1",
     "request": "^2.65.0",
     "tough-cookie": "^2.2.0",
-    "ws": "^0.8.0"
+    "ws": "^1.0.1"
   },
   "devDependencies": {
     "babel": "5.8.29",


### PR DESCRIPTION
This PR builds on PR #1033 to add improve compatibility with older socket.io version that have not yet adopted ws 1.x APIs. In ws 1.x, the binaryType values are checked to only allows `arraybuffer` and the node.js type, `nodebuffer`.

This change allows for comability during the period of adoption so that zombie can be used on node v6 engines with existing socket.io client versions.