### PR TITLE
Support other button-like input fields

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -924,7 +924,7 @@ class Browser extends EventEmitter {
         return elem;
     }
 
-    const inputs = Array.from(this.querySelectorAll('input[type=submit],button'));
+    const inputs = Array.from(this.querySelectorAll('input[type=submit],input[type=button],input[type=reset],button'));
     for (let input of inputs) {
       if (input.name === selector)
         return input;

--- a/test/selection_test.js
+++ b/test/selection_test.js
@@ -21,6 +21,9 @@ describe('Selection', function() {
               <label>Email <input type="text" name="email"></label>
               <label>Password <input type="password" name="password"></label>
               <button>Sign Me Up</button>
+              <input type="reset" value="Reset">
+              <input type="button" value="A generic button">
+              <input type="submit" value="Send">
             </form>
           </div>
           <div class="now">Walking Aimlessly</div>
@@ -135,6 +138,14 @@ describe('Selection', function() {
       it('should return the button with equally text content', function() {
         const elem = browser.querySelector('.now + button');
         assert.equal(browser.button('Do not press!'), elem);
+      });
+      it('should find button-like inputs', function() {
+        const resetButton = browser.querySelector('form input[type="reset"]');
+        const genericButton = browser.querySelector('form input[type="button"]');
+        const submitButton = browser.querySelector('form input[type="submit"]');
+        assert.equal(browser.button('Reset'), resetButton);
+        assert.equal(browser.button('A generic button'), genericButton);
+        assert.equal(browser.button('Send'), submitButton);
       });
     });
   });


### PR DESCRIPTION
Some button widgets (that are actually represented by a standard button) are not selectable using the `button()` helper.

The attached patch supports finding other well know button-like `<input>` elements such as `<input type="button">` and `<input type="reset">` in addition to the already supported `<input type="submit">`.

I intentionally left out from the patch the `<input type="image">`  kind because although it is technically a button, it does not present the usual button look and feel by default so it does not feel that weird not being able to locate it using `button()`