### PR TITLE
Support aborting DONE XMLHttpRequests

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -44,8 +44,14 @@ class XMLHttpRequest {
       this.readyState = XMLHttpRequest.UNSENT;
       return;
     }
-    // Tell any pending request it has been aborted.
-    request.aborted = true;
+    // Aborting a done request sets its readyState to UNSENT and does not trigger a readystatechange event
+    // https://xhr.spec.whatwg.org/#the-abort()-method
+    if (this.readyState === XMLHttpRequest.DONE) {
+      this.readyState = XMLHttpRequest.UNSENT;
+    } else {
+      // Tell any pending request it has been aborted.
+      request.aborted = true;
+    }
     this._response  = null;
     this._error     = null;
     this._pending   = null;


### PR DESCRIPTION
Aborting an already DONE XMLHttpRequest results in a zombie.js JavaScript error:

```
Cannot set property 'aborted' of null
```

The error is caused by this line in xhr.js:

```
    // Tell any pending request it has been aborted.
    request.aborted = true;
```

The problem is that as the request already finished, it is set to null.

I tried to refactor the tests a little bit to reuse the `readyState` tracking code. The same code is duplicated in other places in the script but as I'm not sure if it will be positively received I did not change the other occurrences :). I would not mind sending a new pull request with that, though.

