### PR TITLE
Remove reference to io.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Well, that was easy.
 
 ## Installing
 
-To install Zombie.js you will need [io.js](https://iojs.org/):
+To install Zombie.js you will need [Node.js](https://nodejs.org/):
 
 ```bash
 $ npm install zombie --save-dev


### PR DESCRIPTION
Changing reference of io.js to Node.js since it is EOL at this point.