### PR TITLE
btoa atob fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zombie",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "Insanely fast, full-stack, headless browser testing using Node.js",
   "homepage": "https://www.npmjs.com/package/zombie",
   "author": "Assaf Arkin <assaf@labnotes.org> (http://labnotes.org/)",

--- a/src/document.js
+++ b/src/document.js
@@ -161,8 +161,8 @@ function setupWindow(window, args) {
   window.FormData =       Fetch.FormData;
 
   // Base-64 encoding/decoding
-  window.atob = (string)=> new Buffer(string, 'base64').toString('utf8');
-  window.btoa = (string)=> new Buffer(string, 'utf8').toString('base64');
+  window.atob = (string)=> new Buffer(string, 'base64').toString('binary');
+  window.btoa = (string)=> new Buffer(string, 'binary').toString('base64');
 
   // Constructor for XHLHttpRequest
   window.XMLHttpRequest = ()=> new XMLHttpRequest(window);


### PR DESCRIPTION
This fixes btoa and atob function to match browser's specs. 
It should use binary format not utf8. Current implementation breaks libraries like pako, this fixes it