### PR TITLE
Adds response.time

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -353,6 +353,8 @@ class Request extends Body {
     if (this.redirect !== 'error')
       this.redirect = 'follow';
     this._redirectCount = 0;
+
+    this.time = Date.now()
   }
 
   // -- From Request interface --

--- a/test/resources_test.js
+++ b/test/resources_test.js
@@ -45,6 +45,10 @@ describe('Resources', function() {
     it('should include loaded JavaScript', function() {
       assert.equal(browser.resources[1].response.url, 'http://example.com/scripts/jquery-2.0.3.js');
     });
+    it('should include timing information', function() {
+      assert(browser.resources[0].request.time != null);
+      assert(browser.resources[0].response.time != null);
+    });
   });
 
 


### PR DESCRIPTION
Adds a .time field to the request object, as used by resources.js:25 for
calculating the request latency.