### PR TITLE
Adds location.port and location.searchParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ms": "^2.1.1",
     "request": "^2.85.0",
     "tough-cookie": "^2.3.4",
+    "whatwg-url": "^7.0.0",
     "ws": "^6.1.2"
   },
   "devDependencies": {

--- a/src/document.js
+++ b/src/document.js
@@ -60,7 +60,10 @@ class DOMURL {
     if (base)
       url = URL.resolve(base, url);
     const parsed = URL.parse(url || 'about:blank');
+
     const origin = parsed.protocol && parsed.hostname && `${parsed.protocol}//${parsed.hostname}`;
+    const port = parsed.port || '';
+
     Object.defineProperties(this, {
       hash:     { value: parsed.hash,         enumerable: true },
       host:     { value: parsed.host,         enumerable: true },
@@ -69,8 +72,8 @@ class DOMURL {
       origin:   { value: origin,              enumerable: true },
       password: { value: parsed.password,     enumerable: true },
       pathname: { value: parsed.pathname,     enumerable: true },
-      port:     { value: parsed.port,         enumerable: true },
-      protocol: { value: parsed.protocol,     enumerable: true  },
+      port:     { value: port,                enumerable: true },
+      protocol: { value: parsed.protocol,     enumerable: true },
       search:   { value: parsed.search,       enumerable: true },
       username: { value: parsed.username,     enumerable: true }
     });

--- a/src/document.js
+++ b/src/document.js
@@ -16,6 +16,7 @@ const WebSocket       = require('ws');
 const Window          = require('jsdom/lib/jsdom/browser/Window');
 const XMLHttpRequest  = require('./xhr');
 const { idlUtils }    = require('./dom/impl');
+const whatwgURL       = require('whatwg-url');
 
 // File access, not implemented yet
 class File {
@@ -48,41 +49,6 @@ class Screen {
   get pixelDepth() {
     return 24;
   }
-}
-
-
-// DOM implementation of URL class
-class DOMURL {
-
-  constructor(url, base) {
-    if (url == null)
-       throw new TypeError('Failed to construct \'URL\': Invalid URL');
-    if (base)
-      url = URL.resolve(base, url);
-    const parsed = URL.parse(url || 'about:blank');
-
-    const origin = parsed.protocol && parsed.hostname && `${parsed.protocol}//${parsed.hostname}`;
-    const port = parsed.port || '';
-
-    Object.defineProperties(this, {
-      hash:     { value: parsed.hash,         enumerable: true },
-      host:     { value: parsed.host,         enumerable: true },
-      hostname: { value: parsed.hostname,     enumerable: true },
-      href:     { value: URL.format(parsed),  enumerable: true },
-      origin:   { value: origin,              enumerable: true },
-      password: { value: parsed.password,     enumerable: true },
-      pathname: { value: parsed.pathname,     enumerable: true },
-      port:     { value: port,                enumerable: true },
-      protocol: { value: parsed.protocol,     enumerable: true },
-      search:   { value: parsed.search,       enumerable: true },
-      username: { value: parsed.username,     enumerable: true }
-    });
-  }
-
-  toString() {
-    return this.href;
-  }
-
 }
 
 
@@ -174,7 +140,7 @@ function setupWindow(window, args) {
 
   // Constructor for XHLHttpRequest
   window.XMLHttpRequest = XMLHttpRequest.bind(null, window);
-  window.URL = DOMURL;
+  window.URL = whatwgURL.URL;
 
   // Web sockets
   window._allWebSockets = [];

--- a/src/history.js
+++ b/src/history.js
@@ -140,6 +140,11 @@ class Location {
     const url  = Object.assign(URL.parse(this._url), { search: value });
     this.assign(URL.format(url));
   }
+
+  get searchParams() {
+    return URL.parse(this._url).searchParams ||
+      new URLSearchParams();
+  }
 }
 
 

--- a/src/history.js
+++ b/src/history.js
@@ -142,8 +142,10 @@ class Location {
   }
 
   get searchParams() {
-    return URL.parse(this._url).searchParams ||
-      new URLSearchParams();
+    const url = URL.parse(this._url);
+    
+    if (url.search == null) return null; 
+    return new URL.URLSearchParams(url.search);
   }
 }
 

--- a/test/document_test.js
+++ b/test/document_test.js
@@ -28,6 +28,25 @@ describe('Document', function() {
     });
   });
 
+  describe('location/DOMURL', function() {
+    before(function() {
+      brains.get('/somepath', function(req, res) {
+        res.send('<html></html>');
+      });
+
+      return browser.visit('/somepath');
+    });
+
+    describe('.port', function() {
+      it('should be a string', function() {
+        const location = browser.location;
+
+        // Browsers type this as ?string.
+        assert.equal(location.port, ''); 
+      })
+    });
+  });
+
 
   describe('activeElement', function() {
     before(function() {

--- a/test/document_test.js
+++ b/test/document_test.js
@@ -34,7 +34,7 @@ describe('Document', function() {
         res.send('<html></html>');
       });
 
-      return browser.visit('/somepath');
+      return browser.visit('/somepath?foo=bar');
     });
 
     describe('port', function() {
@@ -48,10 +48,15 @@ describe('Document', function() {
     describe('searchParams', function() {
       it('should be present', function() {
         const searchParams = browser.location.searchParams; 
-        const keys = Array.from(searchParams.keys());
-        
-        assert(Array.isArray(keys));
-        assert.equal(keys.length, 0);
+
+        assert.strictEqual(searchParams.get('foo'), 'bar');
+      });
+
+      describe('when no query is specified', function() {
+        it('is undefined', function() {
+          browser.visit('/somepath');
+          assert.equal(browser.location.searchParams, null); 
+        });
       });
     });
   });

--- a/test/document_test.js
+++ b/test/document_test.js
@@ -37,13 +37,22 @@ describe('Document', function() {
       return browser.visit('/somepath');
     });
 
-    describe('.port', function() {
+    describe('port', function() {
       it('should be a string', function() {
         const location = browser.location;
 
         // Browsers type this as ?string.
         assert.equal(location.port, ''); 
       })
+    });
+    describe('searchParams', function() {
+      it('should be present', function() {
+        const searchParams = browser.location.searchParams; 
+        const keys = Array.from(searchParams.keys());
+        
+        assert(Array.isArray(keys));
+        assert.equal(keys.length, 0);
+      });
     });
   });
 


### PR DESCRIPTION
Additionally this PR removes the old DOMURL implementation; the code now uses NodeJS' standard 'url' library and 'whatwg-url'. The old DOMURL was very similar to whatwg-url; tests pass, so I am assuming that this can go. 