### PR TITLE
Emit on MessageEvent

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -456,6 +456,10 @@ function setupWindow(window, args) {
     event.initMessageEvent('message', false, false, data, eventOrigin, null, source, []);
 
     this.dispatchEvent(event);
+
+    const handled = browser.emit('message', data);
+    if (!handled)
+      browser.log('Unhandled message("%s")');
   };
 
   // Inject HTMLDocument.hasFocus function


### PR DESCRIPTION
I changed this for myself but thought maybe it could be useful generally. It allows you to listen for `postMessage` in the same way as `alert` or `confirm` - something like

```
Browser.extend(function(browser) {
	browser.on('message', function(data) {
		console.log('postMessage fired', data);
	});
});
```