### PR TITLE
docs: Fix simple typo, comparision -> comparison

### DIFF
--- a/test/scripts/jquery-1.4.4.js
+++ b/test/scripts/jquery-1.4.4.js
@@ -3012,7 +3012,7 @@ var chunker = /((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[
 	baseHasDuplicate = true;
 
 // Here we check if the JavaScript engine is using some sort of
-// optimization where it does not always call our comparision
+// optimization where it does not always call our comparison
 // function. If that is the case, discard the hasDuplicate value.
 //   Thus far that includes Google Chrome.
 [0, 0].sort(function() {

--- a/test/scripts/jquery-1.5.1.js
+++ b/test/scripts/jquery-1.5.1.js
@@ -3311,7 +3311,7 @@ var chunker = /((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[
 	rNonWord = /\W/;
 
 // Here we check if the JavaScript engine is using some sort of
-// optimization where it does not always call our comparision
+// optimization where it does not always call our comparison
 // function. If that is the case, discard the hasDuplicate value.
 //   Thus far that includes Google Chrome.
 [0, 0].sort(function() {

--- a/test/scripts/jquery-1.6.3.js
+++ b/test/scripts/jquery-1.6.3.js
@@ -3782,7 +3782,7 @@ var chunker = /((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[
 	rNonWord = /\W/;
 
 // Here we check if the JavaScript engine is using some sort of
-// optimization where it does not always call our comparision
+// optimization where it does not always call our comparison
 // function. If that is the case, discard the hasDuplicate value.
 //   Thus far that includes Google Chrome.
 [0, 0].sort(function() {

--- a/test/scripts/jquery-1.7.1.js
+++ b/test/scripts/jquery-1.7.1.js
@@ -3868,7 +3868,7 @@ var chunker = /((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[
 	rNonWord = /\W/;
 
 // Here we check if the JavaScript engine is using some sort of
-// optimization where it does not always call our comparision
+// optimization where it does not always call our comparison
 // function. If that is the case, discard the hasDuplicate value.
 //   Thus far that includes Google Chrome.
 [0, 0].sort(function() {

--- a/test/scripts/jquery-1.8.0.js
+++ b/test/scripts/jquery-1.8.0.js
@@ -4513,7 +4513,7 @@ Sizzle.error = function( msg ) {
 };
 
 // Check if the JavaScript engine is using some sort of
-// optimization where it does not always call our comparision
+// optimization where it does not always call our comparison
 // function. If that is the case, discard the hasDuplicate value.
 //   Thus far that includes Google Chrome.
 [0, 0].sort(function() {


### PR DESCRIPTION
There is a small typo in test/scripts/jquery-1.4.4.js, test/scripts/jquery-1.5.1.js, test/scripts/jquery-1.6.3.js, test/scripts/jquery-1.7.1.js, test/scripts/jquery-1.8.0.js.

Should read `comparison` rather than `comparision`.

